### PR TITLE
ClassNames - Allow digits after the first char

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/naming/ClassNames.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/naming/ClassNames.scala
@@ -10,7 +10,7 @@ class ClassNames extends Inspection {
 
       import context.global._
 
-      private val regex = "^[A-Z][A-Za-z]*$"
+      private val regex = "^[A-Z][A-Za-z0-9]*$"
 
       override def inspect(tree: Tree): Unit = {
         tree match {


### PR DESCRIPTION
There are classes where it makes sense to include a digit in a class name along with chars (Tuple2, Tuple3, etc being a good use-case that already exists in scala); the current regex doesn't allow that.
