### PR TITLE
Allow all inspections to be disabled

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -67,37 +67,44 @@ class ScapegoatComponent(val global: Global, inspections: Seq[Inspection])
   override val phaseName: String = "scapegoat"
   override val runsAfter: List[String] = List("typer")
   override val runsBefore = List[String]("patmat")
+  
+  val disableAll = disabled.exists(_.compareToIgnoreCase("all"))
 
   def activeInspections = inspections.filterNot(inspection => disabled.contains(inspection.getClass.getSimpleName))
   lazy val feedback = new Feedback(consoleOutput)
 
   override def newPhase(prev: scala.tools.nsc.Phase): Phase = new Phase(prev) {
     override def run(): Unit = {
-
-      if (verbose) {
-        println(s"[info] [scapegoat] ${activeInspections.size} activated inspections")
-        if (ignoredFiles.size > 0)
-          println(s"[info] [scapegoat] $ignoredFiles ignored file patterns")
-      }
-      super.run()
-
-      if (summary) {
-        val errors = feedback.errors.size
-        val warns = feedback.warns.size
-        val infos = feedback.infos.size
-        val level = if (errors > 0) "error" else if (warns > 0) "warn" else "info"
-        println(s"[$level] [scapegoat] Analysis complete - $errors errors $warns warns $infos infos")
-      }
-
-      if (!disableHTML) {
-        val html = IOUtils.writeHTMLReport(dataDir, feedback)
-        if (verbose)
-          println(s"[info] [scapegoat] Written HTML report [$html]")
-      }
-      if (!disableXML) {
-        val xml = IOUtils.writeXMLReport(dataDir, feedback)
-        if (verbose)
-          println(s"[info] [scapegoat] Written XML report [$xml]")
+      if (disableAll) {
+        if (verbose) {
+          println("[info] [scapegoat] All inspections disabled")
+        }
+      } else {
+        if (verbose) {
+          println(s"[info] [scapegoat] ${activeInspections.size} activated inspections")
+          if (ignoredFiles.size > 0)
+            println(s"[info] [scapegoat] $ignoredFiles ignored file patterns")
+        }
+        super.run()
+  
+        if (summary) {
+          val errors = feedback.errors.size
+          val warns = feedback.warns.size
+          val infos = feedback.infos.size
+          val level = if (errors > 0) "error" else if (warns > 0) "warn" else "info"
+          println(s"[$level] [scapegoat] Analysis complete - $errors errors $warns warns $infos infos")
+        }
+  
+        if (!disableHTML) {
+          val html = IOUtils.writeHTMLReport(dataDir, feedback)
+          if (verbose)
+            println(s"[info] [scapegoat] Written HTML report [$html]")
+        }
+        if (!disableXML) {
+          val xml = IOUtils.writeXMLReport(dataDir, feedback)
+          if (verbose)
+            println(s"[info] [scapegoat] Written XML report [$xml]")
+        }
       }
     }
   }
@@ -105,25 +112,27 @@ class ScapegoatComponent(val global: Global, inspections: Seq[Inspection])
   protected def newTransformer(unit: CompilationUnit): Transformer = new Transformer(unit)
 
   class Transformer(unit: global.CompilationUnit) extends TypingTransformer(unit) {
-    override def transform(tree: global.Tree) = {
-      if (ignoredFiles.exists(unit.source.path.matches)) {
-        if (debug) {
-          println(s"[debug] Skipping scapegoat [$unit]")
+    override def transform(tree: global.Tree) = 
+      if (disableAll) {
+        if (ignoredFiles.exists(unit.source.path.matches)) {
+          if (debug) {
+            println(s"[debug] Skipping scapegoat [$unit]")
+          }
+          tree
+        } else {
+          if (debug) {
+            println(s"[debug] Scapegoat analysis [$unit] .....")
+          }
+          val context = new InspectionContext(global, feedback)
+          activeInspections.foreach(inspection => {
+            val inspector = inspection.inspector(context)
+            val traverser = inspector.traverser
+            traverser.traverse(tree.asInstanceOf[inspector.context.global.Tree])
+            inspector.postInspection()
+          })
         }
-        tree
-      } else {
-        if (debug) {
-          println(s"[debug] Scapegoat analysis [$unit] .....")
-        }
-        val context = new InspectionContext(global, feedback)
-        activeInspections.foreach(inspection => {
-          val inspector = inspection.inspector(context)
-          val traverser = inspector.traverser
-          traverser.traverse(tree.asInstanceOf[inspector.context.global.Tree])
-          inspector.postInspection()
-        })
-        tree
       }
+      tree
     }
   }
 }


### PR DESCRIPTION
I have some auto-generated code (from scalaxb for example) that fails... a lot of checks.  Given that a human isn't responsible for making sure it works, I disable all 'linters' on those projects which were entirely made by a script / tool.  I tried -Xplugin-disable as I do other ones but then I get odd errors relating to settings or something... this seems like the an easy solution.  Guessed a good way to do this but if you have a better way feel free to ignore this.

Also I just made the changes in GitHub so I apologize if there are any syntax errors.
