### PR TITLE
disableAll must be computed when needed

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -68,7 +68,7 @@ class ScapegoatComponent(val global: Global, inspections: Seq[Inspection])
   override val runsAfter: List[String] = List("typer")
   override val runsBefore = List[String]("patmat")
 
-  val disableAll = disabled.exists(_.compareToIgnoreCase("all") == 0)
+  def disableAll = disabled.exists(_.compareToIgnoreCase("all") == 0)
 
   def activeInspections = inspections.filterNot(inspection => disabled.contains(inspection.getClass.getSimpleName))
   lazy val feedback = new Feedback(consoleOutput)


### PR DESCRIPTION
When this is a val, it is defined before the disabled setting has been fully populated by sbt.

Turning it into a def fixes this "race condition".
