### PR TITLE
Added linter and compiler warnings to build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,22 @@ def check(code: String) = {
 }
 """
 
+resolvers += "linter" at "http://hairyfotr.github.io/linteRepo/releases"
+
+addCompilerPlugin("com.foursquare.lint" %% "linter" % "0.1-SNAPSHOT")
+
+scalacOptions ++= Seq(
+  "-Xlint",
+  "-Ywarn-adapted-args",
+  "-Ywarn-dead-code",
+  "-Ywarn-inaccessible",
+  "-Ywarn-infer-any",
+  "-Ywarn-nullary-override",
+  "-Ywarn-nullary-unit",
+  "-Ywarn-numeric-widen"
+  //"-Ywarn-value-discard"
+)
+  
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Ref #79.
I've commented out value-discard, as it has 5 false positives.

You might want to take a look at https://github.com/HairyFotr/linter/blob/master/staticanalysis.sbt
Wartremover was broken when I was writing this, and cpd/findbugs aren't usually very relevant to scala (probably not enough to be in the main build.sbt).
