### PR TITLE
Add CatchException and CatchFatal inspections

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ There are currently 107 inspections. An overview list is given, followed by a mo
 | ArrayEquals | Checks for comparison of arrays using `==` which will always return false |
 | ArraysInFormat| Checks for arrays passed to String.format |
 | ArraysToString| Checks for explicit toString calls on arrays |
-| AvoidOperatorOverload | Checks for mental symbolic method names | 
+| AvoidOperatorOverload | Checks for mental symbolic method names |
 | AvoidSizeEqualsZero | Traversable.size can be slow for some data structure, prefer .isEmpty |
 | AvoidSizeNotEqualsZero | Traversable.size can be slow for some data structure, prefer .nonEmpty |
 | AvoidToMinusOne | Checks for loops that use `x to n-1` instead of `x until n` |
@@ -97,6 +97,8 @@ There are currently 107 inspections. An overview list is given, followed by a mo
 | BoundedByFinalType | Looks for types with upper bounds of a final type |
 | BrokenOddness| checks for a % 2 == 1 for oddness because this fails on negative numbers |
 | CatchNpe| Checks for try blocks that catch null pointer exceptions |
+| CatchException | Checks for try blocks that catch Exception |
+| CatchFatal | Checks for try blocks that catch fatal exceptions: VirtualMachineError, ThreadDeath, InterruptedException, LinkageError, ControlThrowable |
 | CatchThrowable | Checks for try blocks that catch Throwable |
 | ClassNames | Ensures class names adhere to the style guidelines |
 | CollectionNamingConfusion| Checks for variables that are confusingly named |
@@ -167,7 +169,7 @@ There are currently 107 inspections. An overview list is given, followed by a mo
 | StripMarginOnRegex | Checks for .stripMargin on regex strings that contain a pipe |
 | SubstringZero | Checks for `String.substring(0)` |
 | SuspiciousMatchOnClassObject | Finds code where matching is taking place on class literals |
-| SwallowedException | Finds catch blocks that don't handle caught exceptions | 
+| SwallowedException | Finds catch blocks that don't handle caught exceptions |
 | SwapSortFilter| `sort.filter` can be replaced with `filter.sort` for performance |
 | TraversableHead| Looks for unsafe usage of `Traversable.head` |
 | TryGet| Checks for use of `Try.get` |

--- a/src/main/scala/com/sksamuel/scapegoat/ScapegoatConfig.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/ScapegoatConfig.scala
@@ -35,6 +35,8 @@ object ScapegoatConfig extends App {
     new BoundedByFinalType,
     new BrokenOddness,
     new CatchNpe,
+    new CatchException,
+    new CatchFatal,
     new CatchThrowable,
     new ClassNames,
     new CollectionNamingConfusion,

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchException.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchException.scala
@@ -1,0 +1,36 @@
+package com.sksamuel.scapegoat.inspections.exception
+
+import com.sksamuel.scapegoat.{ Inspection, InspectionContext, Inspector, Levels }
+
+/** @author Marconi Lanna */
+class CatchException extends Inspection {
+
+  def inspector(context: InspectionContext): Inspector = new Inspector(context) {
+    override def postTyperTraverser = Some apply new context.Traverser {
+
+      import context.global._
+
+      def catchesException(cases: List[CaseDef]) = {
+        cases.exists {
+          // matches t : Exception
+          case CaseDef(Bind(_, Typed(_, tpt)), _, _) if tpt.tpe =:= typeOf[Exception] => true
+          // matches _ : Exception
+          case CaseDef(Typed(_, tpt), _, _) if tpt.tpe =:= typeOf[Exception] => true
+          case _ => false
+        }
+      }
+
+      override def inspect(tree: Tree): Unit = {
+        tree match {
+          case Try(_, cases, _) if catchesException(cases) =>
+            context.warn("Catch exception",
+              tree.pos,
+              Levels.Warning,
+              "Did you intend to catch all exceptions, consider catching a more specific exception class: " +
+                tree.toString().take(300), CatchException.this)
+          case _ => continue(tree)
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchFatal.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/CatchFatal.scala
@@ -1,0 +1,46 @@
+package com.sksamuel.scapegoat.inspections.exception
+
+import com.sksamuel.scapegoat.{ Inspection, InspectionContext, Inspector, Levels }
+
+import scala.util.control.ControlThrowable
+
+/** @author Marconi Lanna */
+class CatchFatal extends Inspection {
+
+  def inspector(context: InspectionContext): Inspector = new Inspector(context) {
+    override def postTyperTraverser = Some apply new context.Traverser {
+
+      import context.global._
+
+      def isFatal(tpe: context.global.Type) = {
+        tpe =:= typeOf[VirtualMachineError] ||
+          tpe =:= typeOf[ThreadDeath] ||
+          tpe =:= typeOf[InterruptedException] ||
+          tpe =:= typeOf[LinkageError] ||
+          tpe =:= typeOf[ControlThrowable]
+      }
+
+      def catchesFatal(cases: List[CaseDef]) = {
+        cases.exists {
+          // matches t : FatalException
+          case CaseDef(Bind(_, Typed(_, tpt)), _, _) if isFatal(tpt.tpe) => true
+          // matches _ : FatalException
+          case CaseDef(Typed(_, tpt), _, _) if isFatal(tpt.tpe) => true
+          case _ => false
+        }
+      }
+
+      override def inspect(tree: Tree): Unit = {
+        tree match {
+          case Try(_, cases, _) if catchesFatal(cases) =>
+            context.warn("Catch fatal exception",
+              tree.pos,
+              Levels.Warning,
+              "Did you intend to catch a fatal exception, consider using scala.util.control.NonFatal: " +
+                tree.toString().take(300), CatchFatal.this)
+          case _ => continue(tree)
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchExceptionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchExceptionTest.scala
@@ -1,0 +1,57 @@
+package com.sksamuel.scapegoat.inspections.exception
+
+import com.sksamuel.scapegoat.PluginRunner
+import org.scalatest.{ FreeSpec, Matchers, OneInstancePerTest }
+
+/** @author Marconi Lanna */
+class CatchExceptionTest extends FreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+
+  override val inspections = Seq(new CatchException)
+
+  "catch _ exception" - {
+    "should report warning" in {
+
+      val code1 = """object Test {
+                        try {
+                        } catch {
+                          case t : Throwable =>
+                          case _ : Exception =>
+                        }
+                    } """.stripMargin
+
+      compileCodeSnippet(code1)
+      compiler.scapegoat.feedback.warnings.size shouldBe 1
+    }
+  }
+  "catch e exception" - {
+    "should report warning" in {
+
+      val code2 = """object Test {
+                        try {
+                        } catch {
+                          case e : RuntimeException =>
+                          case x : Exception =>
+                          case f : Throwable =>
+                        }
+                    } """.stripMargin
+
+      compileCodeSnippet(code2)
+      compiler.scapegoat.feedback.warnings.size shouldBe 1
+    }
+  }
+  "catch without exception case" - {
+    "should not report warning" in {
+
+      val code2 = """object Test {
+                        try {
+                        } catch {
+                          case e : RuntimeException =>
+                          case f : Throwable =>
+                        }
+                    } """.stripMargin
+
+      compileCodeSnippet(code2)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+  }
+}

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchFatalTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchFatalTest.scala
@@ -1,0 +1,57 @@
+package com.sksamuel.scapegoat.inspections.exception
+
+import com.sksamuel.scapegoat.PluginRunner
+import org.scalatest.{ FreeSpec, Matchers, OneInstancePerTest }
+
+/** @author Marconi Lanna */
+class CatchFatalTest extends FreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+
+  override val inspections = Seq(new CatchFatal)
+
+  "catch _ fatal exception" - {
+    "should report warning" in {
+
+      val code1 = """object Test {
+                        try {
+                        } catch {
+                          case e : Exception =>
+                          case _ : VirtualMachineError =>
+                        }
+                    } """.stripMargin
+
+      compileCodeSnippet(code1)
+      compiler.scapegoat.feedback.warnings.size shouldBe 1
+    }
+  }
+  "catch e fatal exception" - {
+    "should report warning" in {
+
+      val code2 = """object Test {
+                        try {
+                        } catch {
+                          case e : RuntimeException =>
+                          case x : ThreadDeath =>
+                          case f : Exception =>
+                        }
+                    } """.stripMargin
+
+      compileCodeSnippet(code2)
+      compiler.scapegoat.feedback.warnings.size shouldBe 1
+    }
+  }
+  "catch without fatal exception case" - {
+    "should not report warning" in {
+
+      val code2 = """object Test {
+                        try {
+                        } catch {
+                          case e : RuntimeException =>
+                          case f : Exception =>
+                        }
+                    } """.stripMargin
+
+      compileCodeSnippet(code2)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+  }
+}


### PR DESCRIPTION
Analogous to `CatchThrowable` this adds `CatchException` and `CatchFatal` inspections to flag harmful exceptions. Source: http://www.scala-lang.org/api/2.11.7/#scala.util.control.NonFatal$