### PR TITLE
Added checks for reverse.tail.reverse and reverse.head

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/ScapegoatConfig.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/ScapegoatConfig.scala
@@ -106,6 +106,8 @@ object ScapegoatConfig extends App {
     new RedundantFinalModifierOnMethod,
     new RedundantFinalModifierOnVar,
     new RepeatedCaseBody,
+    new ReverseTailReverse,
+    new ReverseHead,
     new SimplifyBooleanExpression,
     new StripMarginOnRegex,
     new SubstringZero,

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ReverseHead.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ReverseHead.scala
@@ -1,0 +1,22 @@
+package com.sksamuel.scapegoat.inspections.collections
+
+import com.sksamuel.scapegoat._
+
+class ReverseHead extends Inspection {
+
+  def inspector(context: InspectionContext): Inspector = new Inspector(context) {
+    override def postTyperTraverser = Some apply new context.Traverser {
+
+      import context.global._
+
+      override def inspect(tree: Tree): Unit = {
+        tree match {
+          case Select(Select(_, TermName("reverse")), TermName("head")) =>
+            context.warn("reverse.head instead of last", tree.pos, Levels.Info,
+              ".reverse.head can be replaced with last: " + tree.toString().take(500), ReverseHead.this)
+          case _ => continue(tree)
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTailReverse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTailReverse.scala
@@ -1,0 +1,22 @@
+package com.sksamuel.scapegoat.inspections.collections
+
+import com.sksamuel.scapegoat._
+
+class ReverseTailReverse extends Inspection {
+
+  def inspector(context: InspectionContext): Inspector = new Inspector(context) {
+    override def postTyperTraverser = Some apply new context.Traverser {
+
+      import context.global._
+
+      override def inspect(tree: Tree): Unit = {
+        tree match {
+          case Select(Select(Select(_, TermName("reverse")), TermName("tail")), TermName("reverse")) =>
+            context.warn("reverse.tail.reverse instead of init", tree.pos, Levels.Info,
+              ".reverse.tail.reverse can be replaced with init: " + tree.toString().take(500), ReverseTailReverse.this)
+          case _ => continue(tree)
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ReverseHeadTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ReverseHeadTest.scala
@@ -1,0 +1,24 @@
+package com.sksamuel.scapegoat.inspections.collections
+
+import com.sksamuel.scapegoat.PluginRunner
+import org.scalatest.{ FreeSpec, Matchers, OneInstancePerTest }
+
+class ReverseHeadTest
+    extends FreeSpec
+    with Matchers
+    with PluginRunner
+    with OneInstancePerTest {
+
+  override val inspections = Seq(new ReverseHead)
+
+  "ReverseHead" - {
+    "should report warning" in {
+      val code = """class Test {
+                     List(1,2,3).reverse.head
+                    } """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 1
+    }
+  }
+}

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTailReverseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTailReverseTest.scala
@@ -1,0 +1,24 @@
+package com.sksamuel.scapegoat.inspections.collections
+
+import com.sksamuel.scapegoat.PluginRunner
+import org.scalatest.{ FreeSpec, Matchers, OneInstancePerTest }
+
+class ReverseTailReverseTest
+    extends FreeSpec
+    with Matchers
+    with PluginRunner
+    with OneInstancePerTest {
+
+  override val inspections = Seq(new ReverseTailReverse)
+
+  "ReverseTailReverse" - {
+    "should report warning" in {
+      val code = """class Test {
+                     List(1,2,3).reverse.tail.reverse
+                    } """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 1
+    }
+  }
+}


### PR DESCRIPTION
Added inspections:

* reverse.tail.reverse can be replaced with init
* reverse.head can be replaced with last
