### PR TITLE
UnusedMethodParameter shouldn't warn for methods that have a body of type Nothing

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnusedMethodParameter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnusedMethodParameter.scala
@@ -89,6 +89,9 @@ class UnusedMethodParameter extends Inspection {
           // ignore methods that just throw, e.g. "???"
           case DefDef(_, _, _, _, tpt, _) if tpt.tpe =:= NothingTpe                                   =>
 
+          // ignore methods that just throw, e.g. "???" or "js.native"
+          case DefDef(_, _, _, _, _, rhs) if rhs.tpe =:= NothingTpe                                   =>
+
           // ignore overriden methods, the parameter might be used by other classes
           case DefDef(mods, _, _, _, _, _) if mods.isOverride ||
             mods.hasFlag(Flags.OVERRIDE) ||

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnusedMethodParameterTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnusedMethodParameterTest.scala
@@ -60,6 +60,16 @@ class UnusedMethodParameterTest
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+      "for methods not returning when their return type is specified" in {
+        pendingUntilFixed {
+          val code = """class Test {
+                     |  def foo(name:String): String = throw new RuntimeException
+                     |}""".stripMargin
+
+          compileCodeSnippet(code)
+          compiler.scapegoat.feedback.warnings.size shouldBe 0
+        }
+      }
       "for overriden method" in {
         val code = """package com.sam
                       trait Foo {
@@ -95,6 +105,27 @@ class UnusedMethodParameterTest
 
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+
+      "for js.native defined method" in {
+        pendingUntilFixed {
+          val code = """package scala.scalajs {
+                          object js {
+                            def native: Nothing = ???
+                          }
+                        }
+
+                        package com.sam {
+                        
+                        import scalajs.js
+                        
+                        class Foo {
+                          def foo(name: String): String = js.native
+                        }
+                        } """
+          compileCodeSnippet(code)
+          compiler.scapegoat.feedback.warnings.size shouldBe 0
+        }
       }
     }
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnusedMethodParameterTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnusedMethodParameterTest.scala
@@ -61,14 +61,12 @@ class UnusedMethodParameterTest
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
       "for methods not returning when their return type is specified" in {
-        pendingUntilFixed {
-          val code = """class Test {
-                     |  def foo(name:String): String = throw new RuntimeException
-                     |}""".stripMargin
+        val code = """class Test {
+                   |  def foo(name:String): String = throw new RuntimeException
+                   |}""".stripMargin
 
-          compileCodeSnippet(code)
-          compiler.scapegoat.feedback.warnings.size shouldBe 0
-        }
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
       "for overriden method" in {
         val code = """package com.sam
@@ -108,24 +106,23 @@ class UnusedMethodParameterTest
       }
 
       "for js.native defined method" in {
-        pendingUntilFixed {
-          val code = """package scala.scalajs {
-                          object js {
-                            def native: Nothing = ???
-                          }
+        val code = """package scala.scalajs {
+                        object js {
+                          def native: Nothing = ???
                         }
+                      }
 
-                        package com.sam {
-                        
-                        import scalajs.js
-                        
-                        class Foo {
-                          def foo(name: String): String = js.native
-                        }
-                        } """
-          compileCodeSnippet(code)
-          compiler.scapegoat.feedback.warnings.size shouldBe 0
-        }
+                      package com.sam {
+                      
+                      import scalajs.js
+                      
+                      class Foo {
+                        def foo(name: String): String = js.native
+                      }
+                      } """
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+
       }
     }
 


### PR DESCRIPTION
Previously, we only ommitted the warning when the return type of the function is Nothing, now we also omit it when the body has type Nothing.

Rational is that return Nothing means non-normal return like throwing an exception or ???. Or also the use case of using js.native. In these cases, you shouldn't be warned when you don't use the parameters.

Also adds tests and checked that the tests succeed.

This fixes #143.