### PR TITLE
Use full file path when generating Scalastyle XML report

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -35,11 +35,12 @@ class Feedback(consoleOutput: Boolean, reporter: Reporter) {
       case None                => level
     }
 
-    val sourceFile = normalizeSourceFile(pos.source.file.path)
-    val warning = Warning(text, pos.line, adjustedLevel, sourceFile, snippet, inspection.getClass.getCanonicalName)
+    val sourceFileFull = pos.source.file.path
+    val sourceFileNormalized = normalizeSourceFile(sourceFileFull)
+    val warning = Warning(text, pos.line, adjustedLevel, sourceFileFull, sourceFileNormalized, snippet, inspection.getClass.getCanonicalName)
     warnings.append(warning)
     if (consoleOutput) {
-      println(s"[${warning.level.toString.toLowerCase}] $sourceFile:${warning.line}: $text")
+      println(s"[${warning.level.toString.toLowerCase}] $sourceFileNormalized:${warning.line}: $text")
       snippet.foreach(s => println(s"          $s"))
       println()
     }
@@ -61,6 +62,7 @@ class Feedback(consoleOutput: Boolean, reporter: Reporter) {
 case class Warning(text: String,
   line: Int,
   level: Level,
-  sourceFile: String,
+  sourceFileFull: String,
+  sourceFileNormalized: String,
   snippet: Option[String],
   inspection: String)

--- a/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
@@ -91,7 +91,7 @@ object HtmlReportWriter {
   def warnings(reporter: Feedback) = {
     reporter.warnings.map {
       case warning =>
-        val source = warning.sourceFile + ":" + warning.line
+        val source = warning.sourceFileNormalized + ":" + warning.line
         <div class="warning">
           <div class="source">
             { source }

--- a/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
@@ -13,7 +13,7 @@ object ScalastyleReportWriter {
 
   def toXML(feedback: Feedback): Node = {
     <checkstyle version={ checkstyleVersion } generatedBy={ scapegoat }>
-      { feedback.warnings.groupBy(_.sourceFile).map(fileToXml) }
+      { feedback.warnings.groupBy(_.sourceFileFull).map(fileToXml) }
     </checkstyle>
   }
 

--- a/src/main/scala/com/sksamuel/scapegoat/io/XmlReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/XmlReportWriter.scala
@@ -14,6 +14,6 @@ object XmlReportWriter {
   }
 
   private def warning2xml(warning: Warning) = {
-    <warning line={ warning.line.toString } text={ warning.text } snippet={ warning.snippet.orNull } level={ warning.level.toString } file={ warning.sourceFile } inspection={ warning.inspection }/>
+    <warning line={ warning.line.toString } text={ warning.text } snippet={ warning.snippet.orNull } level={ warning.level.toString } file={ warning.sourceFileNormalized } inspection={ warning.inspection }/>
   }
 }


### PR DESCRIPTION
Fix for #151 

- split existing `Feedback.sourceFile` into `sourceFileFull` and `sourceFileNormalized`
- `sourceFileFull` is the absolute path of the source file on disk, now used in the Scalastyle XML generator
- `sourceFileNormalized` is used everywhere else as previously