### PR TITLE
Fix false positive in ComparingUnrelatedTypes when comparing to integral literals

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypes.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypes.scala
@@ -11,9 +11,37 @@ class ComparingUnrelatedTypes extends Inspection {
       import context.global._
 
       override def inspect(tree: Tree): Unit = {
+
+        def isIntegral(t: Type) =
+          Seq(typeOf[Byte], typeOf[Char], typeOf[Short], typeOf[Int], typeOf[Long]).exists(t <:< _)
+
+        def integralLiteralFitsInType(literal: Literal, targetType: Type): Boolean = {
+          if (!isIntegral(literal.tpe) || !isIntegral(targetType)) {
+            false
+          } else {
+            // convertTo has built-in range checking and will return null if the value cannot be
+            // accurately represented in the target type.
+            literal.value.convertTo(targetType) != null
+          }
+        }
+
         tree match {
+          // -- Special cases ---------------------------------------------------------------------
+
+          // Comparing any numeric value to a literal 0 should be ignored:
           case Apply(Select(lhs, TermName("$eq$eq")), List(Literal(Constant(0)))) if lhs.tpe.typeSymbol.isNumericValueClass =>
           case Apply(Select(Literal(Constant(0)), TermName("$eq$eq")), List(rhs)) if rhs.tpe.typeSymbol.isNumericValueClass =>
+
+          // Comparing a integral value to a integral literal should be ignored if the literal
+          // fits in the in range of the other value's type. For example, in general it may be
+          // unsafe to compare ints to chars because not all ints fit in the range of a char, but
+          // such comparisons are safe for small integers: thus `(c: Char) == 97` is a valid
+          // comparision but `(c: Char) == 128000` is not.
+          case Apply(Select(value, TermName("$eq$eq")), List(lit @ Literal(_))) if integralLiteralFitsInType(lit, value.tpe) =>
+          case Apply(Select(lit @ Literal(_), TermName("$eq$eq")), List(value)) if integralLiteralFitsInType(lit, value.tpe)  =>
+
+          // -- End special cases ------------------------------------------------------------------
+
           case Apply(Select(lhs, TermName("$eq$eq")), List(rhs)) =>
             def related(lt: Type, rt: Type) =
               lt <:< rt || rt <:< lt || lt =:= rt


### PR DESCRIPTION
The ComparingUnrelatedTypes rule would often trigger false positives in comparisons against integral type literals. For example,

```
val x = 1
x == 100L
```

would trigger a false positive even though this is a safe comparision because the long value `100L` fits within an `Int` type.

To avoid such false-positive, this patch extends the ComparingUnrelatedTypes rule to add special-case checks for the comparision of an integral value to a literal integral value. In such cases, we check whether the literal is a valid value of the other value's type.  Thus `(c: Char) == 97` is considered valid but `(c: Char) == 128000` is not.

Fixes #111.