### PR TITLE
#164 Use Traversable base type of container type

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifableToContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifableToContains.scala
@@ -15,13 +15,15 @@ class ExistsSimplifableToContains extends Inspection {
       import context.global._
 
       private val Equals = TermName("$eq$eq")
-      private def isTraversable(tree: Tree) = tree.tpe <:< typeOf[Traversable[_]]
+
+      private def isTraversable(tree: Tree) = tree.tpe <:< typeOf[Traversable[Any]]
+
       private def isContainsType(container: Tree, value: Tree): Boolean = {
-        val l = value.tpe.underlying.typeSymbol.tpe
-        container.tpe.underlying.typeArgs.headOption match {
-          case Some(t) =>
-            l <:< t || l =:= t
-          case None => false
+        val valueType = value.tpe.underlying.typeSymbol.tpe
+        val traversableType = container.tpe.underlying.baseType(typeOf[Traversable[Any]].typeSymbol)
+        traversableType.typeArgs match {
+          case t :: _ => valueType <:< t || valueType =:= t
+          case _ => false
         }
       }
 

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifableToContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifableToContains.scala
@@ -27,7 +27,7 @@ class ExistsSimplifableToContains extends Inspection {
       override def inspect(tree: Tree): Unit = {
         tree match {
           case Apply(Select(lhs, TermName("exists")), List(Function(_, Apply(Select(_, Equals), List(x))))) if isTraversable(lhs) && isContainsType(lhs, x) =>
-            context.warn("Exists simplifable to contains",
+            context.warn("Exists simplifiable to contains",
               tree.pos,
               Levels.Info,
               "exists(x => x == y) can be replaced with contains(y): " + tree.toString().take(500),

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifableToContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifableToContains.scala
@@ -21,10 +21,7 @@ class ExistsSimplifableToContains extends Inspection {
       private def isContainsType(container: Tree, value: Tree): Boolean = {
         val valueType = value.tpe.underlying.typeSymbol.tpe
         val traversableType = container.tpe.underlying.baseType(typeOf[Traversable[Any]].typeSymbol)
-        traversableType.typeArgs match {
-          case t :: _ => valueType <:< t || valueType =:= t
-          case _ => false
-        }
+        traversableType.typeArgs.exists(t => valueType <:< t || valueType =:= t)
       }
 
       override def inspect(tree: Tree): Unit = {

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifableToContainsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifableToContainsTest.scala
@@ -15,10 +15,11 @@ class ExistsSimplifableToContainsTest extends FreeSpec with Matchers with Plugin
           |val exists1 = List(1,2,3).exists(x => x == 2)
           |val list = List("sam", "spade")
           |val exists2 = list.exists(_ == "spoof")
+          |val exists3 = (1 to 3).exists(_ == 2)
           |} """.stripMargin
 
       compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 2
+      compiler.scapegoat.feedback.warnings.size shouldBe 3
     }
   }
 


### PR DESCRIPTION
Use Traversable base type of container type to determine type parameter; covers parameter-less container types.