### PR TITLE
add MapGetAndGetOrElse inspection

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/ScapegoatConfig.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/ScapegoatConfig.scala
@@ -84,6 +84,7 @@ object ScapegoatConfig extends App {
     new ListSize,
     new LooksLikeInterpolatedString,
     new LonelySealedTrait,
+    new MapGetAndGetOrElse,
     new MaxParameters,
     new MethodNames,
     new MethodReturningAny,

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
@@ -1,0 +1,35 @@
+package com.sksamuel.scapegoat.inspections.collections
+
+import com.sksamuel.scapegoat._
+
+/**
+ * @author Sanjiv Sahayam
+ *
+ * Inspired by Intellij inspection that does:
+ *   myMap.get(key).getOrElse(defaultValue) –> myMap.getOrElse(key, defaultValue)
+ */
+class MapGetAndGetOrElse extends Inspection {
+
+  def inspector(context: InspectionContext): Inspector = new Inspector(context) {
+    override def postTyperTraverser = Some apply new context.Traverser {
+
+      import context.global._
+
+      private def isMap(tree: Tree): Boolean = tree.tpe <:< typeOf[scala.collection.MapLike[_, _, _]]
+
+      override def inspect(tree: Tree): Unit = {
+        tree match {
+          case Apply(TypeApply(Select(Apply(Select(left, TermName("get")), List(key)),
+            TermName("getOrElse")), _), List(defaultValue)) if isMap(left) =>
+            context.warn(
+              s"Use of .get.getOrElse instead of .getOrElse",
+              tree.pos,
+              Levels.Error,
+              s"Use of .get($key).getOrElse($defaultValue) instead of getOrElse($key, $defaultValue): " + tree.toString().take(500),
+              MapGetAndGetOrElse.this)
+          case _ => continue(tree)
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
@@ -1,5 +1,0 @@
-package com.sksamuel.scapegoat.inspections.collections
-
-class MapGetAndGetOrElse {
-
-}

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElseTest.scala
@@ -1,0 +1,45 @@
+package com.sksamuel.scapegoat.inspections.collections
+
+import com.sksamuel.scapegoat.PluginRunner
+import org.scalatest.{ FreeSpec, Matchers }
+
+class MapGetAndGetOrElseTest extends FreeSpec with Matchers with PluginRunner {
+
+  override val inspections = Seq(new MapGetAndGetOrElse)
+
+  private def getOrElseAssertion(code: String): Unit = {
+    compileCodeSnippet(code)
+    compiler.scapegoat.feedback.warnings.size shouldBe 1
+    compiler.scapegoat.feedback.warnings.head.text shouldBe ("Use of .get.getOrElse instead of .getOrElse")
+  }
+
+  "Map with get followed by getOrElse" - {
+    "should report a warning" - {
+      "when used with the default scala.Map" in {
+        val code = """class Test {
+                     | val numMap = Map(1 -> "one", 2 -> "two")
+                     | numMap.get(1).getOrElse("unknown")
+                     } """.stripMargin
+
+        getOrElseAssertion(code)
+      }
+
+      "when used with a mutable Map" in {
+        val code = """class Test {
+             | val numMap = scala.collection.mutable.Map("one" -> 1, "two" -> 2)
+             | numMap.get("one").getOrElse(-1)
+             } """.stripMargin
+
+       getOrElseAssertion(code)
+      }
+
+      "when used with a Map definition" in {
+        val code = """class Test {
+             | Map("John" -> "Smith", "Peter" -> "Rabbit").get("Sarah").getOrElse("-")
+             } """.stripMargin
+
+       getOrElseAssertion(code)
+      }
+    }
+  }
+}


### PR DESCRIPTION
If you need to lookup a key in a Map and then return a default value
if the key does not exist in the Map such as:

```
someMap.get(key).getOrElse(defaultValue)
```

This inspection will propose this simplified code instead:

```
someMap.getOrElse(key, defaultValue)
```

which does the same thing.

Inspired by the Intellij inspection that does the same.