### PR TITLE
Fix issue with Circe deriveDecoder call

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
@@ -83,6 +83,7 @@ case class InspectionContext(global: Global, feedback: Feedback) {
         case mod: ModuleDef if isSuppressed(mod.symbol) =>
         case ClassDef(_, _, _, Template(parents, _, _)) if parents.map(_.tpe.typeSymbol.fullName).contains("scala.reflect.api.TypeCreator") =>
         case classdef: ClassDef if isSuppressed(classdef.symbol) =>
+        case _ if analyzer.hasMacroExpansionAttachment(tree) => //skip macros as per http://bit.ly/2uS8BrU
         case _ => inspect(tree)
       }
     }


### PR DESCRIPTION
This fixes #173 for Circe macros, at least in the case of calling
```deriveDecoder```. This could also fix other macro issues we have,
but I need someone to test this.