### PR TITLE
fix for #178

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatch.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatch.scala
@@ -19,7 +19,7 @@ class PartialFunctionInsteadOfMatch extends Inspection {
       }
 
       private def isPFBind(name: TermName) = {
-        val b = name.toString.matches("x0\\$\\d")
+        val b = name.toString.matches("x0\\$\\d+")
         b
       }
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatchTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatchTest.scala
@@ -49,6 +49,42 @@ class PartialFunctionInsteadOfMatchTest
                        case i: Int =>
                        case s: String =>
                      }
+                     list.map {
+                       case i: Int =>
+                       case s: String =>
+                     }
+                     list.map {
+                       case i: Int =>
+                       case s: String =>
+                     }
+                     list.map {
+                       case i: Int =>
+                       case s: String =>
+                     }
+                     list.map {
+                       case i: Int =>
+                       case s: String =>
+                     }
+                     list.map {
+                       case i: Int =>
+                       case s: String =>
+                     }
+                     list.map {
+                       case i: Int =>
+                       case s: String =>
+                     }
+                     list.map {
+                       case i: Int =>
+                       case s: String =>
+                     }
+                     list.map {
+                       case i: Int =>
+                       case s: String =>
+                     }
+                     list.map {
+                       case i: Int =>
+                       case s: String =>
+                     }
 
                      val future = Future { }
                      future onComplete {


### PR DESCRIPTION
Fix for #178. Partial function style can use more than one digit after `$` in `x0$1`.