### PR TITLE
Fix comparison inspections to also work for inequality (Issue #189)

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingFloatingPointTypes.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingFloatingPointTypes.scala
@@ -12,10 +12,11 @@ class ComparingFloatingPointTypes extends Inspection(
       import context.global._
 
       private val EqEq = TermName("$eq$eq")
+      private val BangEq =  TermName("$bang$eq")
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Apply(Select(left, EqEq), List(right)) =>
+          case Apply(Select(left, EqEq | BangEq), List(right)) =>
             val leftType = Option(left.tpe).map(_.typeSymbol).map(_.fullName).orNull
             val rightType = Option(right.tpe).map(_.typeSymbol).map(_.fullName).orNull
             val leftFloating = leftType == "scala.Double" || leftType == "scala.Float"

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypes.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypes.scala
@@ -29,20 +29,20 @@ class ComparingUnrelatedTypes extends Inspection("Comparing unrelated types", Le
           // -- Special cases ---------------------------------------------------------------------
 
           // Comparing any numeric value to a literal 0 should be ignored:
-          case Apply(Select(lhs, TermName("$eq$eq")), List(Literal(Constant(0)))) if lhs.tpe.typeSymbol.isNumericValueClass =>
-          case Apply(Select(Literal(Constant(0)), TermName("$eq$eq")), List(rhs)) if rhs.tpe.typeSymbol.isNumericValueClass =>
+          case Apply(Select(lhs, TermName("$eq$eq" | "$bang$eq")), List(Literal(Constant(0)))) if lhs.tpe.typeSymbol.isNumericValueClass =>
+          case Apply(Select(Literal(Constant(0)), TermName("$eq$eq" | "$bang$eq")), List(rhs)) if rhs.tpe.typeSymbol.isNumericValueClass =>
 
           // Comparing a integral value to a integral literal should be ignored if the literal
           // fits in the in range of the other value's type. For example, in general it may be
           // unsafe to compare ints to chars because not all ints fit in the range of a char, but
           // such comparisons are safe for small integers: thus `(c: Char) == 97` is a valid
           // comparision but `(c: Char) == 128000` is not.
-          case Apply(Select(value, TermName("$eq$eq")), List(lit @ Literal(_))) if integralLiteralFitsInType(lit, value.tpe) =>
-          case Apply(Select(lit @ Literal(_), TermName("$eq$eq")), List(value)) if integralLiteralFitsInType(lit, value.tpe)  =>
+          case Apply(Select(value, TermName("$eq$eq" | "$bang$eq")), List(lit @ Literal(_))) if integralLiteralFitsInType(lit, value.tpe) =>
+          case Apply(Select(lit @ Literal(_), TermName("$eq$eq" | "$bang$eq")), List(value)) if integralLiteralFitsInType(lit, value.tpe)  =>
 
           // -- End special cases ------------------------------------------------------------------
 
-          case Apply(Select(lhs, TermName("$eq$eq")), List(rhs)) =>
+          case Apply(Select(lhs, TermName("$eq$eq" | "$bang$eq")), List(rhs)) =>
             def related(lt: Type, rt: Type) =
               lt <:< rt || rt <:< lt || lt =:= rt
             def isDerivedValueClass(ts: Symbol) = ts.isClass && ts.asClass.isDerivedValueClass

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparisonWithSelf.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparisonWithSelf.scala
@@ -18,7 +18,7 @@ class ComparisonWithSelf extends Inspection("Comparision with self", Levels.Warn
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Apply(Select(left, TermName("$eq$eq")), List(right)) =>
+          case Apply(Select(left, TermName("$eq$eq" | "$bang$eq")), List(right)) =>
             if (left.toString() == right.toString())
               context.warn(tree.pos,self)
           case _ => continue(tree)

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingFloatingPointTypesTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingFloatingPointTypesTest.scala
@@ -20,11 +20,12 @@ class ComparingFloatingPointTypesTest
                         val a = 14.5
                         val b = 15.6
                         a == b
+                        a != b
                       }
                     } """.stripMargin
 
         compileCodeSnippet(code)
-        compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compiler.scapegoat.feedback.warnings.size shouldBe 2
       }
       "for float comparison" in {
         val code = """class Test {
@@ -32,11 +33,12 @@ class ComparingFloatingPointTypesTest
                         val a = 14.5f
                         val b = 15.6f
                         a == b
+                        a != b
                       }
                     } """.stripMargin
 
         compileCodeSnippet(code)
-        compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compiler.scapegoat.feedback.warnings.size shouldBe 2
       }
     }
   }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypesTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypesTest.scala
@@ -16,68 +16,70 @@ class ComparingUnrelatedTypesTest extends FreeSpec with Matchers with PluginRunn
 
   "ComparingUnrelatedTypes" - {
     "should report warning" in {
-      val code = """
+      def code(comparisonOp: String) = s"""
         case class SomeValueClass(i: Int) extends AnyVal
         class Test {
           val a = new RuntimeException
           val b = new Exception
 
-          "sammy" == BigDecimal(10) // warning 1
-          "sammy" == "bobby" // same type
-          a == b // superclass
-          a == "sammy" // warning 2
-          Some("sam") == Option("laura") // ok
-          Nil == Set.empty // warning 3
+          "sammy" $comparisonOp BigDecimal(10) // warning 1
+          "sammy" $comparisonOp "bobby" // same type
+          a $comparisonOp b // superclass
+          a $comparisonOp "sammy" // warning 2
+          Some("sam") $comparisonOp Option("laura") // ok
+          Nil $comparisonOp Set.empty // warning 3
 
           Some(1) match {
-            case Some(x) if x == SomeValueClass(1) => () // warning 4
+            case Some(x) if x $comparisonOp SomeValueClass(1) => () // warning 4
             case _ => ()
           }
 
           def foo[K <: Option[String]](in: K): Boolean = {
-            in == Some(1) // warning 5
-            in == SomeValueClass(3) // warning 6
-            in == Some("somestring") // warning 7 (ideally we could avoid this)
-            in == Option("somestring") // ok
+            in $comparisonOp Some(1) // warning 5
+            in $comparisonOp SomeValueClass(3) // warning 6
+            in $comparisonOp Some("somestring") // warning 7 (ideally we could avoid this)
+            in $comparisonOp Option("somestring") // ok
           }
 
           def foo2[K](in: K): Boolean = {
-            in == Some(1) // warning 8
-            in == SomeValueClass(3) // warning 9
-            in == in // ok
+            in $comparisonOp Some(1) // warning 8
+            in $comparisonOp SomeValueClass(3) // warning 9
+            in $comparisonOp in // ok
           }
 
           def foo3[K <: J, J](in: K, in2: J): Boolean = {
-            in == Some(1) // warning 10
-            in2 == Some(1) // warning 11
-            in == in // ok
-            in == in2 // ok
-            in2 == in2 // ok
+            in $comparisonOp Some(1) // warning 10
+            in2 $comparisonOp Some(1) // warning 11
+            in $comparisonOp in // ok
+            in $comparisonOp in2 // ok
+            in2 $comparisonOp in2 // ok
           }
 
           def foo4[K <: Option[Option[String]]](in: K): Boolean = {
-            in == Some(Some(1)) // warning 12
-            in == SomeValueClass(3) // warning 13
-            in == Some(Some("somestring")) // warning 14 (ideally we could avoid this)
-            in == Option(Option("somestring")) // ok
+            in $comparisonOp Some(Some(1)) // warning 12
+            in $comparisonOp SomeValueClass(3) // warning 13
+            in $comparisonOp Some(Some("somestring")) // warning 14 (ideally we could avoid this)
+            in $comparisonOp Option(Option("somestring")) // ok
           }
 
-          Some(1) == Some("somestring") // warning 15
+          Some(1) $comparisonOp Some("somestring") // warning 15
           Option(Option("1")) == Some(Some("2")) // ok
 
           val f: Float = 1.0f
           val d: Double = 1.0d
-          f == 1 // warning 16
-          d == 1 // warning 17
+          f $comparisonOp 1 // warning 16
+          d $comparisonOp 1 // warning 17
 
           val c: Char = 'a'
-          c == -1 // warning 18
-          c == 65536 // warning 19
+          c $comparisonOp -1 // warning 18
+          c $comparisonOp 65536 // warning 19
 
           val i: Int = 1
           i == -2147483649L // warning 20
         } """.stripMargin
-      compileCodeSnippet(code)
+      compileCodeSnippet(code("=="))
+      compiler.scapegoat.feedback.warnings.size shouldBe 20
+      compileCodeSnippet(code("!="))
       compiler.scapegoat.feedback.warnings.size shouldBe 20
     }
     "should not report warning" - {

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparisonWithSelfInspectionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparisonWithSelfInspectionTest.scala
@@ -14,11 +14,12 @@ class ComparisonWithSelfInspectionTest extends FreeSpec with Matchers with Plugi
       val code = """object Test {
                       val b = true
                       if (b == b) {
+                      } else if(b != b) {
                       }
                     } """.stripMargin
 
       compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 1
+      compiler.scapegoat.feedback.warnings.size shouldBe 2
     }
   }
 }


### PR DESCRIPTION
I investigate the cause for issue #189 and turns out it happened because the comparison inspections were only done for "==" and not for "!=". This PR aims to fix that.