### PR TITLE
IllegalFormatString should allow format strings with width >= 10

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/IllegalFormatString.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/IllegalFormatString.scala
@@ -8,7 +8,7 @@ import com.sksamuel.scapegoat._
 class IllegalFormatString extends Inspection("Illegal format string", Levels.Error) {
 
   // format is: %[argument_index$][flags][width][.precision][t]conversion
-  final val argRegex = "%(\\d+\\$)?[-#+ 0,(\\<]*?\\d?(\\.\\d+)?[tT]?[a-zA-Z]".r
+  final val argRegex = "%(\\d+\\$)?[-#+ 0,(\\<]*?\\d*(\\.\\d+)?[tT]?[a-zA-Z]".r
 
   def inspector(context: InspectionContext): Inspector = new Inspector(context) {
     override def postTyperTraverser = Some apply new context.Traverser {

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/IllegalFormatStringTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/IllegalFormatStringTest.scala
@@ -85,4 +85,15 @@ class IllegalFormatStringTest extends FreeSpec with Matchers with PluginRunner w
       compiler.scapegoat.feedback.warnings.size shouldBe 0
     }
   }
+  "format string with large width" - {
+    "should not report warning" in {
+
+      val code = """object Test {
+                      "%010d".format(0)
+                   } """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+  }
 }


### PR DESCRIPTION
Without this change it improperly rejects format strings like this one:

```
"%010d".format(0)
// => "0000000000"
```