### PR TITLE
Add "unsafe string contains" inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Please note that scapegoat is a new project. While it's been tested on some comm
 
 ### Inspections
 
-There are currently 116 inspections. An overview list is given, followed by a more detailed description of each inspection after the list (todo: finish rest of detailed descriptions)
+There are currently 117 inspections. An overview list is given, followed by a more detailed description of each inspection after the list (todo: finish rest of detailed descriptions)
 
 | Name | Brief Description | Default Level |
 |------|-------------------|---------------|
@@ -234,6 +234,7 @@ There are currently 116 inspections. An overview list is given, followed by a mo
 | UnnecessaryToString | Checks for unnecessary `toString` on instances of String | Warning |
 | UnreachableCatch | Checks for catch clauses that cannot be reached | Warning |
 | UnsafeContains | Checks for `List.contains(value)` for invalid types | Error |
+| UnsafeStringContains | Checks for `String.contains(value)` for invalid types | Error |
 | UnusedMethodParameter | Checks for unused method parameters | Warning |
 | UseCbrt | Checks for use of `math.pow` for calculating `math.cbrt` | Info |
 | UseExpM1 | Checks for use of `math.exp(x) - 1` instead of `math.expm1(x)` | Info |

--- a/src/main/scala/com/sksamuel/scapegoat/ScapegoatConfig.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/ScapegoatConfig.scala
@@ -128,6 +128,7 @@ object ScapegoatConfig extends App {
     new UnnecessaryToString,
     new UnreachableCatch,
     new UnsafeContains,
+    new UnsafeStringContains,
     new UnusedMethodParameter,
     new UseCbrt,
     new UseExpM1,

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/UnsafeStringContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/UnsafeStringContains.scala
@@ -1,0 +1,36 @@
+package com.sksamuel.scapegoat.inspections.string
+
+import com.sksamuel.scapegoat._
+
+/** @author Zack Grannan */
+class UnsafeStringContains extends Inspection("Unsafe string contains", Levels.Error) {
+
+  def inspector(context: InspectionContext): Inspector = new Inspector(context) {
+    override def postTyperTraverser = Some apply new context.Traverser {
+
+      import context.global._
+      import treeInfo.Applied
+
+      private val Contains = TermName("contains")
+
+      private def isChar(tree: Tree) = tree.tpe.widen.baseClasses.contains(typeOf[Char].typeSymbol)
+
+      private def isString(tree: Tree): Boolean = {
+        tree.tpe.widen.baseClasses.contains(typeOf[String].typeSymbol) || (tree match {
+          case Apply(left, _) => left.symbol.fullName == "scala.Predef.augmentString"
+          case _ => false
+        })
+      }
+
+      private def isCompatibleType(value: Tree) = isString(value) || isChar(value)
+
+      override def inspect(tree: Tree): Unit = tree match {
+        case Applied(Select(lhs, Contains), _, (arg :: Nil) :: Nil) if isString(lhs) && !isCompatibleType(arg) =>
+          context.warn(tree.pos, self, tree.toString().take(300))
+        case _ =>
+          continue(tree)
+      }
+    }
+  }
+}
+

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/UnsafeStringContainsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/UnsafeStringContainsTest.scala
@@ -1,0 +1,29 @@
+package com.sksamuel.scapegoat.inspections.string
+
+import com.sksamuel.scapegoat.PluginRunner
+import org.scalatest.{OneInstancePerTest, FreeSpec, Matchers}
+
+/** @author Zack Grannan */
+class UnsafeStringContainsTest extends FreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+  override val inspections = Seq(new UnsafeStringContains)
+  "unsafe string contains" - {
+    "should report warning" in {
+      val code =
+        """
+          |object Test {
+          |  "abcdefgh".contains(2) // bad
+          |  "abcdefgh".contains(2:Char) // good
+          |  "abcdefgh".contains(new Object) // bad
+          |  val str: String = ""
+          |  str.contains(2L) // bad
+          |  "abcd".contains("abc") // good
+          |  "abcd".contains('b') // good
+          |  str.contains("abc") // good
+          |  str.contains('b') // good
+          |}""".stripMargin.trim
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 3
+    }
+  }
+
+}


### PR DESCRIPTION
This new inspection is similar to the `UnsafeContains` exception, except that it operates on `String` instead of `List`. The purpose is to raise an error for code that is obviously wrong, like the following:

```scala
"abcdefgh".contains(new Object)
```