### PR TITLE
handle false positive in unnecessary return use

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryReturnUse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryReturnUse.scala
@@ -13,7 +13,7 @@ class UnnecessaryReturnUse extends Inspection("Unnecessary return", Levels.Info,
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Block(_, Return(expr)) =>
+          case DefDef(_, _, _, _, _, Block(_, Return(_))) =>
             context.warn(tree.pos, self)
           case _ => continue(tree)
         }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryReturnUseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryReturnUseTest.scala
@@ -17,6 +17,14 @@ class UnnecessaryReturnUseTest extends FreeSpec with Matchers with PluginRunner 
                         val s = "sammy"
                         return s
                       }
+
+                      def earlyOutReturn: Unit = {
+                        if(Math.random() > 0.5) {
+                          println("early out return")
+                          return () // Acceptable
+                        }
+                        println("not reachable")
+                      }
                     } """.stripMargin
 
       compileCodeSnippet(code)


### PR DESCRIPTION
In the case that `return` is used to get out of a function early, the `UnnecessaryReturnUse` inspection throws a false positive if the return keyword happens to be at the end of a block.