### PR TITLE
Fix spurious UnreachableCatch when some catch cases are conditional

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/UnreachableCatch.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/UnreachableCatch.scala
@@ -14,17 +14,20 @@ class UnreachableCatch extends Inspection("Unreachable catch", Levels.Warning) {
 
       def isUnreachable(cases: List[CaseDef]) = {
         val types = mutable.HashSet[Type]()
-          def check(tpe: Type): Boolean = {
-            if (types.exists(tpe <:< _)) true
-            else {
+        def check(tpe: Type, guard: Tree): Boolean = {
+          if (types.exists(tpe <:< _)) {
+            true
+          } else {
+            if (guard == EmptyTree) {
               types.add(tpe)
-              false
             }
+            false
           }
+        }
         cases.exists {
           // matches t : Throwable
-          case CaseDef(Bind(_, Typed(_, tpt)), _, _) => check(tpt.tpe)
-          case CaseDef(Typed(_, tpt), _, _) if tpt.tpe =:= typeOf[Throwable] => check(tpt.tpe)
+          case CaseDef(Bind(_, Typed(_, tpt)), guard, _) => check(tpt.tpe, guard)
+          case CaseDef(Typed(_, tpt), guard, _) if tpt.tpe =:= typeOf[Throwable] => check(tpt.tpe, guard)
           case _ => false
         }
       }
@@ -33,7 +36,7 @@ class UnreachableCatch extends Inspection("Unreachable catch", Levels.Warning) {
         tree match {
           case Try(_, cases, _) if isUnreachable(cases) =>
             context.warn(tree.pos, self,
-              "One or more cases are unreachable" + tree.toString().take(300))
+              "One or more cases are unreachable " + tree.toString().take(300))
           case _ => continue(tree)
         }
       }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/UnreachableCatchTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/UnreachableCatchTest.scala
@@ -27,6 +27,19 @@ class UnreachableCatchTest
         compileCodeSnippet(code1)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+
+      "when unconditional catch is followed by conditional catch on the same type" in {
+        val code = """object Test {
+                        try {
+                        } catch {
+                          case e: RuntimeException =>
+                          case e: RuntimeException if e.getMessage.contains("foo") =>
+                        }
+                    } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 1
+      }
     }
     "should not report warning" - {
       "for super type after sub type" in {
@@ -41,6 +54,32 @@ class UnreachableCatchTest
                     } """.stripMargin
 
         compileCodeSnippet(code2)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+
+      "when conditional catch is followed by unconditional catch on the same type" in {
+        val code = """object Test {
+                        try {
+                        } catch {
+                          case e: RuntimeException if e.getMessage.contains("foo") =>
+                          case e: RuntimeException =>
+                        }
+                    } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+
+      "when conditional catch is followed by conditional catch on the same type" in {
+        val code = """object Test {
+                        try {
+                        } catch {
+                          case e: RuntimeException if e.getMessage.contains("foo") =>
+                          case e: RuntimeException if e.getMessage.contains("bar") =>
+                        }
+                    } """.stripMargin
+
+        compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
     }


### PR DESCRIPTION
In a try...catch that looks like this:

```
{
  case e: SomeException if condition(e) =>
  case e: SomeException if otherCondition(e) =>
}
```

it would incorrectly report the second case as unreachable, since it didn't
actually examine the `if ...` guards attached to each case.

This change makes it so that if a case is conditional (has a non-empty guard
attached to it), then it's not considered to be redundant with subsequent cases
against the same type, though it is still checked against
previous (unconditional) cases that might have had the same type.

Also fix the formatting of the message, which was missing a space.