### PR TITLE
Handle %% (literal %) in format strings

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormat.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormat.scala
@@ -6,7 +6,8 @@ import com.sksamuel.scapegoat._
 class IncorrectNumberOfArgsToFormat extends Inspection("Incorrect number of args for format", Levels.Error) {
 
   // format is: %[argument_index$][flags][width][.precision][t]conversion
-  final val argRegex = "%(\\d+\\$)?[-#+ 0,(\\<]*?\\d?(\\.\\d+)?[tT]?[a-zA-Z]".r
+  //        OR: %%
+  final val argRegex = "%((\\d+\\$)?[-#+ 0,(\\<]*?\\d?(\\.\\d+)?[tT]?[a-zA-Z]|%)".r
 
   def inspector(context: InspectionContext): Inspector = new Inspector(context) {
     override def postTyperTraverser = Some apply new context.Traverser {
@@ -17,7 +18,8 @@ class IncorrectNumberOfArgsToFormat extends Inspection("Incorrect number of args
         tree match {
           case Apply(Select(Apply(Select(_, TermName("augmentString")), List(Literal(Constant(format)))),
             TermName("format")), args) =>
-            val argCount = argRegex.findAllIn(format.toString).matchData.size
+            // %% doesn't consume any arguments, but all other formats do
+            val argCount = argRegex.findAllIn(format.toString).matchData.filterNot(_.matched == "%%").size
             if (argCount > args.size)
               context.warn(tree.pos, self, tree.toString().take(500))
           case _ => continue(tree)

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormatTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormatTest.scala
@@ -29,6 +29,19 @@ class IncorrectNumberOfArgsToFormatTest extends FreeSpec with Matchers with Plug
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+      "for correct number of args and various number of literal '%'s in format string" in {
+        val code1 = """object Test {    "%%s".format()  } """
+        compileCodeSnippet(code1)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+
+        val code2 = """object Test {    "%%%s".format("sam")  } """
+        compileCodeSnippet(code2)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+
+        val code3 = """object Test {    "%%%%s".format()  } """
+        compileCodeSnippet(code3)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
     }
   }
 }


### PR DESCRIPTION
These should be matched by the scanner and then considered to not consume any
arguments to be interpolated.