### PR TITLE
Fix line numbers and snippets for VarCouldBeVal

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/VarCouldBeVal.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/VarCouldBeVal.scala
@@ -12,18 +12,22 @@ class VarCouldBeVal extends Inspection("Var could be val", Levels.Warning) {
 
       import context.global._
 
-      private def unwrittenVars(tree: Tree, vars: mutable.HashSet[String]): List[String] = {
+      private def unwrittenVars(tree: Tree, vars: mutable.HashMap[String, Tree]): List[(String, Tree)] = {
         tree match {
           case Block(stmt, expr) => containsUnwrittenVar(stmt :+ expr, vars)
           case _                 => containsUnwrittenVar(List(tree), vars)
         }
       }
 
-      private def containsUnwrittenVar(trees: List[Tree], vars: mutable.HashSet[String]): List[String] = {
-        // add var to the set when it is defined, then remove it when it's written to
-        // what's left are unwritten vars
+      private def containsUnwrittenVar(trees: List[Tree], vars: mutable.HashMap[String, Tree]): List[(String, Tree)] = {
+        // As we scan the tree, in `vars: HashMap[String, Tree]` we store an entry for each var
+        // that we encounter. The key gives the name and the value gives the tree of the ValDef
+        // that defines it. Whenever a var is written to, we remove its entry. What remains are
+        // vars that are never written to (and the trees corresponding to the places where they
+        // were defined).
         trees.foreach {
-          case ValDef(mods, name, _, _) if mods.isMutable => vars.add(name.toString)
+          case defn@ValDef(mods, name, _, _) if mods.isMutable =>
+            vars.put(name.toString, defn)
           case Assign(lhs, _) =>
             if (lhs.symbol != null)
               vars.remove(lhs.symbol.name.toString)
@@ -41,16 +45,19 @@ class VarCouldBeVal extends Inspection("Var could be val", Levels.Warning) {
         vars.toList
       }
 
-      private def containsUnwrittenVar(trees: List[Tree]): List[String] = {
-        containsUnwrittenVar(trees, mutable.HashSet[String]())
+      private def containsUnwrittenVar(trees: List[Tree]): List[(String, Tree)] = {
+        containsUnwrittenVar(trees, mutable.HashMap[String, Tree]())
       }
 
       override final def inspect(tree: Tree): Unit = {
         tree match {
           case d @ DefDef(_, _, _, _, _, Block(stmt, expr)) =>
-            for (unwritten <- containsUnwrittenVar(stmt :+ expr)) {
-              context.warn(tree.pos, self,
-                s"$unwritten is never written to, so could be a val: " + tree.toString().take(200))
+            for ((unwritten, definitionTree) <- containsUnwrittenVar(stmt :+ expr)) {
+              context.warn(
+                definitionTree.pos,
+                self,
+                s"$unwritten is never written to, so could be a val: " + definitionTree.toString().take(200)
+              )
             }
           case _ => continue(tree)
         }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/VarCouldBeValTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/VarCouldBeValTest.scala
@@ -49,6 +49,26 @@ class VarCouldBeValTest
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+
+      "with correct line numbers" in {
+        val code =
+          """object Test {
+            |  def foo {
+            |    var bar = 1
+            |    val myValue = 2
+            |    var baz = 3
+            |  }
+            |}""".stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 2
+        val warningsInOrder = compiler.scapegoat.feedback.warnings.sortBy(_.line)
+        val Seq(barWarning, bazWarning) = warningsInOrder
+        barWarning.line shouldBe 3
+        barWarning.snippet should contain("bar is never written to, so could be a val: var bar: Int = 1")
+        bazWarning.line shouldBe 5
+        bazWarning.snippet should contain("baz is never written to, so could be a val: var baz: Int = 3")
+      }
     }
     "should not report warning" - {
       "when var is written to in the method" in {


### PR DESCRIPTION
Previously, the VarCouldBeVal inspection attributed any errors not to the line
where the "var" was defined, but to the line where the enclosing def
started. (The snippet also showed, potentially, all of this enclosing def.)

Instead, we now remember the tree (of type ValDef) that defines each var, and
if it turns out that it's unwritten, we output the line number and snippet
corresponding to that tree.