### PR TITLE
fix false positive for toInt on java Integer

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryToInt.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/UnnecessaryToInt.scala
@@ -13,7 +13,7 @@ class UnnecessaryToInt extends Inspection("Unnecessary toInt", Levels.Warning) {
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Select(lhs, TermName("toInt")) if lhs.tpe <:< IntClass.tpe =>
+          case Select(lhs, TermName("toInt")) if lhs.tpe <:< IntClass.tpe && lhs.symbol.baseClasses.nonEmpty =>
             context.warn(tree.pos, self,
               "Unnecessary invocation of toInt on instance of Int " + tree.toString().take(200))
           case _ =>

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryToIntTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryToIntTest.scala
@@ -38,6 +38,18 @@ class UnnecessaryToIntTest
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+
+      "when invoking toInt on an Integer" in {
+        val code =
+          """object Test {
+                      def test(i: java.lang.Integer) = {
+                        val t = i.toInt
+                      }
+                    }""".stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
     }
   }
 }


### PR DESCRIPTION
The type goes trough some implicit conversions so I didn't find a good
way to actually verify that it is an java.lang.Integer. From my
observations the Integer does not have any baseClasses but scalas Int
does contains Int, AnyVal and Any.

Fixes issue #149