### PR TITLE
Add sourcePath property

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -5,7 +5,7 @@ import scala.reflect.internal.util.Position
 import scala.tools.nsc.reporters.Reporter
 
 /** @author Stephen Samuel */
-class Feedback(consoleOutput: Boolean, reporter: Reporter) {
+class Feedback(consoleOutput: Boolean, reporter: Reporter, sourcePrefix: String) {
 
   val warnings = new ListBuffer[Warning]
 
@@ -40,8 +40,9 @@ class Feedback(consoleOutput: Boolean, reporter: Reporter) {
   }
 
   private def normalizeSourceFile(sourceFile: String): String = {
-    val indexOf = sourceFile.indexOf("src/main/scala/")
-    val packageAndFile = if (indexOf == -1) sourceFile else sourceFile.drop(indexOf).drop("src/main/scala/".length)
+    val indexOf = sourceFile.indexOf(sourcePrefix)
+    val fullPrefix = if (sourcePrefix.endsWith("/")) sourcePrefix else s"$sourcePrefix/"
+    val packageAndFile = if (indexOf == -1) sourceFile else sourceFile.drop(indexOf).drop(fullPrefix.length)
     packageAndFile.replace('/', '.').replace('\\', '.')
   }
 }

--- a/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
@@ -1,17 +1,18 @@
 package com.sksamuel.scapegoat
 
-import org.scalatest.{FreeSpec, Matchers, OneInstancePerTest}
+import org.scalatest.{FreeSpec, Matchers, OneInstancePerTest, PrivateMethodTester}
 
-import scala.reflect.internal.util.NoPosition
+import scala.reflect.internal.util.{NoPosition, OffsetPosition}
 import scala.tools.nsc.reporters.StoreReporter
 
 /** @author Stephen Samuel */
 class FeedbackTest
     extends FreeSpec
     with Matchers
-    with OneInstancePerTest {
+    with OneInstancePerTest with PrivateMethodTester {
 
   val position = NoPosition
+  val defaultSourcePrefix = "src/main/scala/"
 
   class DummyInspection(text: String, defaultLevel: Level) extends Inspection(text, defaultLevel) {
     override def inspector(context: InspectionContext): Inspector = ???
@@ -22,23 +23,51 @@ class FeedbackTest
       "for error" in {
         val inspection = new DummyInspection("My default is Error", Levels.Error)
         val reporter = new StoreReporter
-        val feedback = new Feedback(false, reporter)
+        val feedback = new Feedback(false, reporter, defaultSourcePrefix)
         feedback.warn(position, inspection)
         reporter.infos should contain(reporter.Info(position, "My default is Error", reporter.ERROR))
       }
       "for warning" in {
         val inspection = new DummyInspection("My default is Warning", Levels.Warning)
         val reporter = new StoreReporter
-        val feedback = new Feedback(false, reporter)
+        val feedback = new Feedback(false, reporter, defaultSourcePrefix)
         feedback.warn(position, inspection)
         reporter.infos should contain(reporter.Info(position, "My default is Warning", reporter.WARNING))
       }
       "for info" in {
         val inspection = new DummyInspection("My default is Info", Levels.Info)
         val reporter = new StoreReporter
-        val feedback = new Feedback(false, reporter)
+        val feedback = new Feedback(false, reporter, defaultSourcePrefix)
         feedback.warn(position, inspection)
         reporter.infos should contain(reporter.Info(position, "My default is Info", reporter.INFO))
+      }
+    }
+    "should use proper paths" - {
+      "for `src/main/scala`" in {
+        val normalizeSourceFile = PrivateMethod[String]('normalizeSourceFile)
+        val reporter = new StoreReporter
+        val feedback = new Feedback(true, reporter, defaultSourcePrefix)
+        val source = "src/main/scala/com/sksamuel/scapegoat/Test.scala"
+        val result = feedback invokePrivate normalizeSourceFile(source)
+        result should ===("com.sksamuel.scapegoat.Test.scala")
+      }
+
+      "for `app`" in {
+        val normalizeSourceFile = PrivateMethod[String]('normalizeSourceFile)
+        val reporter = new StoreReporter
+        val feedback = new Feedback(true, reporter, "app/")
+        val source = "app/com/sksamuel/scapegoat/Test.scala"
+        val result = feedback invokePrivate normalizeSourceFile(source)
+        result should ===("com.sksamuel.scapegoat.Test.scala")
+      }
+
+      "should add trailing / to the sourcePrefix automatically" in {
+        val normalizeSourceFile = PrivateMethod[String]('normalizeSourceFile)
+        val reporter = new StoreReporter
+        val feedback = new Feedback(true, reporter, "app/custom")
+        val source = "app/custom/com/sksamuel/scapegoat/Test.scala"
+        val result = feedback invokePrivate normalizeSourceFile(source)
+        result should ===("com.sksamuel.scapegoat.Test.scala")
       }
     }
   }


### PR DESCRIPTION
fixes #215 
It adds `sourcePath` property for the cases when sources are not in `src/main/scala` folder
Also, the `-Pscapegoat:sourcePrefix:<smth>` compiler option is added.

If the solution makes sense, I'll add a PR to the https://github.com/sksamuel/sbt-scapegoat to integrate the new property. 