### PR TITLE
Use https protocol for stylesheet links

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
@@ -64,12 +64,12 @@ object HtmlReportWriter {
     <head>
       <title>Scapegoat Inspection Reporter</title>{
         Unparsed(
-          "<link href=\"http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css\" rel=\"stylesheet\">")
+          "<link href=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css\" rel=\"stylesheet\">")
       }{
         Unparsed(
-          """<link href='http://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700,300italic,400italic,500italic,700italic' rel='stylesheet' type='text/css'>""")
+          """<link href='https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700,300italic,400italic,500italic,700italic' rel='stylesheet' type='text/css'>""")
       }{
-        Unparsed { """<link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>""" }
+        Unparsed { """<link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>""" }
       }<style>
          { css }
        </style>


### PR DESCRIPTION
Loading the generated HTML report over https:// results in blocked mixed content errors due to the default security policy:
```
Blocked loading mixed active content “http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css”
Blocked loading mixed active content “http://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700,300italic,400italic,500italic,700italic”
Blocked loading mixed active content “http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800”
```