### PR TITLE
Fix false positive comparison to empty Set

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptySet.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptySet.scala
@@ -17,8 +17,8 @@ class ComparisonToEmptySet extends Inspection("Comparison to empty set", Levels.
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Apply(Select(_, Equals), List(Apply(TypeApply(Select(Select(_, TermSet), TermApply), _), _))) => warn(tree)
-          case Apply(Select(Apply(TypeApply(Select(Select(_, TermSet), TermApply), _), _), Equals), _) => warn(tree)
+          case Apply(Select(_, Equals), List(Apply(TypeApply(Select(Select(_, TermSet), TermApply), _), List()))) => warn(tree)
+          case Apply(Select(Apply(TypeApply(Select(Select(_, TermSet), TermApply), _), List()), Equals), _) => warn(tree)
           case Apply(Select(_, Equals), List(TypeApply(Select(Select(_, TermSet), Empty), _))) => warn(tree)
           case Apply(Select(TypeApply(Select(Select(_, TermSet), Empty), _), Equals), _) => warn(tree)
           case _ => continue(tree)

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptySetTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptySetTest.scala
@@ -51,5 +51,25 @@ class ComparisonToEmptySetTest extends FreeSpec with Matchers with PluginRunner 
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
     }
+    "should not report warning" - {
+      "for comparing lhs to Set(x)" in {
+        val code = """object Test {
+                        val a = Set(1,2,3)
+                        a == Set(2)
+                    } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+      "for comparing rhs to Set(x)" in {
+        val code = """object Test {
+                        val a = Set(1,2,3)
+                        Set(2) == a
+                    } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+    }
   }
 }


### PR DESCRIPTION
We are receiving a warning for the following code:
```scala
if (aSet == Set("abc")) ...
```
This PR fixes the inspection to only consider `Set()` as empty, not `Set(x[, y...])`.