### PR TITLE
Scala 2.13 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
    - 2.11.12
    - 2.12.6
 script:
-   - sbt clean +test
+   - sbt ++$TRAVIS_SCALA_VERSION clean test
 jdk:
    - oraclejdk8
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 scala:
    - 2.11.12
    - 2.12.6
+   - 2.13.0
 script:
    - sbt ++$TRAVIS_SCALA_VERSION clean test
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,50 @@ SbtPgp.autoImport.useGpg := true
 
 SbtPgp.autoImport.useGpgAgent := true
 
-scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8", "-Xmax-classfile-name", "254")
+val scalac13Options = Seq(
+  "-Xlint:adapted-args",
+  "-Xlint:inaccessible",
+  "-Xlint:infer-any",
+  "-Xlint:nullary-override",
+  "-Xlint:nullary-unit",
+)
+
+val scalac12Options = Seq(
+  "-Xlint:adapted-args",
+  "-Ywarn-inaccessible",
+  "-Ywarn-infer-any",
+  "-Xlint:nullary-override",
+  "-Xlint:nullary-unit",
+  "-Xmax-classfile-name", "254"
+)
+
+val scalac11Options = Seq(
+  "-Ywarn-adapted-args",
+  "-Ywarn-inaccessible",
+  "-Ywarn-infer-any",
+  "-Ywarn-nullary-override",
+  "-Ywarn-dead-code",
+  "-Ywarn-nullary-unit",
+  "-Ywarn-numeric-widen",
+  "-Xmax-classfile-name", "254",
+  //"-Ywarn-value-discard"
+)
+
+scalacOptions := {
+  val common = Seq(
+    "-unchecked",
+    "-deprecation",
+    "-feature",
+    "-encoding", "utf8",
+    "-Xlint"
+  )
+
+  common ++ (scalaBinaryVersion.value match {
+    case "2.11" => scalac11Options
+    case "2.12" => scalac12Options
+    case "2.13" => scalac13Options
+  })
+}
 
 fullClasspath in console in Compile ++= (fullClasspath in Test).value // because that's where "PluginRunner" is
 
@@ -31,31 +74,20 @@ def check(code: String) = {
 }
 """
 
-scalacOptions ++= Seq(
-  "-Xlint",
-  "-Ywarn-adapted-args",
-  "-Ywarn-dead-code",
-  "-Ywarn-inaccessible",
-  "-Ywarn-infer-any",
-  "-Ywarn-nullary-override",
-  "-Ywarn-nullary-unit",
-  "-Ywarn-numeric-widen"
-  //"-Ywarn-value-discard"
-)
-  
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 libraryDependencies ++= Seq(
-  "org.scala-lang"                  %     "scala-reflect"         % scalaVersion.value,
-  "org.scala-lang"                  %     "scala-compiler"        % scalaVersion.value      % "provided",
-  "org.scala-lang.modules"          %%    "scala-xml"             % "1.1.1",
-  "org.scala-lang"                  %     "scala-compiler"        % scalaVersion.value      % "test",
-  "commons-io"                      %     "commons-io"            % "2.5"                   % "test",
-  "org.scalatest"                   %%    "scalatest"             % "3.0.4"                 % "test",
-  "org.mockito"                     %     "mockito-all"           % "1.10.19"               % "test",
-  "joda-time"                       %     "joda-time"             % "2.9.9"                 % "test",
-  "org.joda"                        %     "joda-convert"          % "1.9.2"                 % "test",
-  "org.slf4j"                       %     "slf4j-api"             % "1.7.25"                % "test"
+  "org.scala-lang"                  %     "scala-reflect"           % scalaVersion.value,
+  "org.scala-lang"                  %     "scala-compiler"          % scalaVersion.value      % "provided",
+  "org.scala-lang.modules"          %%    "scala-xml"               % "1.2.0",
+  "org.scala-lang.modules"          %%    "scala-collection-compat" % "2.0.0",
+  "org.scala-lang"                  %     "scala-compiler"          % scalaVersion.value      % "test",
+  "commons-io"                      %     "commons-io"              % "2.5"                   % "test",
+  "org.scalatest"                   %%    "scalatest"               % "3.0.8"                 % "test",
+  "org.mockito"                     %     "mockito-all"             % "1.10.19"               % "test",
+  "joda-time"                       %     "joda-time"               % "2.9.9"                 % "test",
+  "org.joda"                        %     "joda-convert"            % "1.9.2"                 % "test",
+  "org.slf4j"                       %     "slf4j-api"               % "1.7.25"                % "test"
 )
 
 sbtrelease.ReleasePlugin.autoImport.releasePublishArtifactsAction := PgpKeys.publishSigned.value

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := "scalac-scapegoat-plugin"
 organization := "com.sksamuel.scapegoat"
 
 scalaVersion := "2.12.8"
-crossScalaVersions := Seq("2.11.12", scalaVersion.value)
+crossScalaVersions := Seq("2.11.12", "2.13.0", scalaVersion.value)
 
 sbtVersion in Global := "1.1.6"
 

--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -7,7 +7,9 @@ import scala.tools.nsc.reporters.Reporter
 /** @author Stephen Samuel */
 class Feedback(consoleOutput: Boolean, reporter: Reporter, sourcePrefix: String) {
 
-  val warnings = new ListBuffer[Warning]
+  private val warningsBuffer = new ListBuffer[Warning]
+
+  def warnings: Seq[Warning] = warningsBuffer.toSeq
 
   var levelOverridesByInspectionSimpleName: Map[String, Level] = Map.empty
 
@@ -25,7 +27,7 @@ class Feedback(consoleOutput: Boolean, reporter: Reporter, sourcePrefix: String)
     val sourceFileFull = pos.source.file.path
     val sourceFileNormalized = normalizeSourceFile(sourceFileFull)
     val warning = Warning(text, pos.line, adjustedLevel, sourceFileFull, sourceFileNormalized, snippetText, inspection.getClass.getCanonicalName)
-    warnings.append(warning)
+    warningsBuffer.append(warning)
     if (consoleOutput) {
       println(s"[${warning.level.toString.toLowerCase}] $sourceFileNormalized:${warning.line}: $text")
       snippetText.foreach(s => println(s"          $s"))

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/NoSuperClone.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/NoSuperClone.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.{ Inspection, InspectionContext, Inspector }
 
 /** @author Stephen Samuel */
 class NoSuperClone

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
@@ -32,7 +32,7 @@ class CollectionPromotionToAny extends Inspection("Collection promotion to any",
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case TypeApply(Select(l, TermName("$colon$plus")), List(a, r)) =>
+          case TypeApply(Select(l, TermName("$colon$plus")), a :: _) =>
             if (!isAnySeq(l) && isAny(a))
               context.warn(tree.pos, self, tree.toString().take(100))
           case _ => continue(tree)

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
@@ -15,7 +15,7 @@ class MapGetAndGetOrElse extends Inspection("Use of .get.getOrElse instead of .g
 
       import context.global._
 
-      private def isMap(tree: Tree): Boolean = tree.tpe <:< typeOf[scala.collection.MapLike[_, _, _]]
+      private def isMap(tree: Tree): Boolean = tree.tpe <:< typeOf[scala.collection.Map[_, _]]
 
       override def inspect(tree: Tree): Unit = {
         tree match {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefSeqIsMutable.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PredefSeqIsMutable.scala
@@ -1,27 +1,29 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.{ Levels, Inspection, InspectionContext, Inspector }
+import com.sksamuel.scapegoat.{ Levels, Inspection, InspectionContext, Inspector, isScala213 }
 
 /** @author Stephen Samuel */
 class PredefSeqIsMutable extends Inspection("Predef.Seq is mutable", Levels.Info,
   "Predef.Seq aliases scala.collection.mutable.Seq. Did you intend to use an immutable Seq?") {
 
   def inspector(context: InspectionContext): Inspector = new Inspector(context) {
-    override def postTyperTraverser = Some apply new context.Traverser {
+    override def postTyperTraverser = if (isScala213) None else Some(
+      new context.Traverser {
 
-      import context.global._
+        import context.global._
 
-      override def inspect(tree: Tree): Unit = {
-        tree match {
-          case DefDef(mods, _, _, _, _, _) if tree.symbol.isAccessor =>
-          case TypeTree() if tree.tpe.erasure.toString() == "Seq[Any]" => warn(tree)
-          case _ => continue(tree)
+        override def inspect(tree: Tree): Unit = {
+          tree match {
+            case DefDef(mods, _, _, _, _, _) if tree.symbol.isAccessor =>
+            case TypeTree() if tree.tpe.erasure.toString() == "Seq[Any]" => warn(tree)
+            case _ => continue(tree)
+          }
+        }
+
+        def warn(tree: Tree): Unit = {
+          context.warn(tree.pos, self)
         }
       }
-
-      def warn(tree: Tree): Unit = {
-        context.warn(tree.pos, self)
-      }
-    }
+    )
   }
 }

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparisonWithSelf.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/equality/ComparisonWithSelf.scala
@@ -11,11 +11,6 @@ class ComparisonWithSelf extends Inspection("Comparision with self", Levels.Warn
 
       import context.global._
 
-      def containsAssignment(tree: Tree) = tree match {
-        case Assign(_, _) => true
-        case _            => false
-      }
-
       override def inspect(tree: Tree): Unit = {
         tree match {
           case Apply(Select(left, TermName("$eq$eq" | "$bang$eq")), List(right)) =>

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/inference/ProductWithSerializableInferred.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/inference/ProductWithSerializableInferred.scala
@@ -18,7 +18,9 @@ class ProductWithSerializableInferred extends Inspection("Product with Serializa
 
       private def isProductWithSerializable(tpe: Type): Boolean = {
         tpe.typeArgs match {
-          case List(RefinedType(List(Product, Serializable, Obj), decls)) => true
+          case List(RefinedType(parents, decls)) if parents.size == 3 =>
+            Seq(Product, Serializable, Obj).forall(t => parents.exists(_ =:= t))
+
           case _ => false
         }
       }

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseExpM1.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseExpM1.scala
@@ -10,11 +10,6 @@ class UseExpM1 extends Inspection("Use expm1", Levels.Info) {
 
       import context.global._
 
-      def isMathPackage(pack: String) =
-        (pack == "scala.math.`package`"
-          || pack == "java.this.lang.Math"
-          || pack == "java.this.lang.StrictMath")
-
       override def inspect(tree: Tree): Unit = {
         tree match {
           case Apply(Select(Apply(Select(pack, TermName("exp")), List(number)), nme.SUB), List(Literal(Constant(1)))) =>

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseSqrt.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseSqrt.scala
@@ -21,7 +21,7 @@ class UseSqrt extends Inspection("Use sqrt", Levels.Info) {
             context.warn(tree.pos, self,
               s"$math.sqrt is clearer and more performant than $math.pow(x, 0.5)")
           case other =>
-            val q = other
+            other
             continue(tree)
         }
       }

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/ZeroNumerator.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/ZeroNumerator.scala
@@ -9,7 +9,6 @@ class ZeroNumerator extends Inspection("Zero numerator", Levels.Warning,
     override def postTyperTraverser = Some apply new context.Traverser {
 
       import context.global._
-      import definitions._
 
       override def inspect(tree: Tree): Unit = {
         tree match {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/nulls/NullAssignment.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/nulls/NullAssignment.scala
@@ -10,11 +10,6 @@ class NullAssignment extends Inspection("Null assignment", Levels.Warning) {
 
       import context.global._
 
-      def containsNull(trees: List[Tree]) = trees exists {
-        case Literal(Constant(null)) => true
-        case _                       => false
-      }
-
       override def inspect(tree: Tree): Unit = {
         tree match {
           case ValDef(_, _, _, Literal(Constant(null))) => warn(tree)

--- a/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
@@ -2,7 +2,6 @@ package com.sksamuel.scapegoat.io
 
 import com.sksamuel.scapegoat.{ Warning, Feedback }
 
-import scala.collection.mutable.ListBuffer
 import scala.xml.Node
 
 /** @author Eugene Sypachev (Axblade) */
@@ -17,7 +16,7 @@ object ScalastyleReportWriter {
     </checkstyle>
   }
 
-  private def fileToXml(fileWarningMapEntry: (String, ListBuffer[Warning])) = {
+  private def fileToXml(fileWarningMapEntry: (String, Seq[Warning])) = {
     val (file, warnings) = fileWarningMapEntry
     <file name={ file }>
       { warnings.map(warningToXml) }

--- a/src/main/scala/com/sksamuel/scapegoat/package.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/package.scala
@@ -1,0 +1,8 @@
+package com.sksamuel
+
+package object scapegoat {
+  val scalaVersion = util.Properties.versionNumberString
+  val shortScalaVersion = scalaVersion.split('.').dropRight(1).mkString(".")
+
+  val isScala213 = shortScalaVersion == "2.13"
+}

--- a/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
@@ -2,7 +2,7 @@ package com.sksamuel.scapegoat
 
 import org.scalatest.{FreeSpec, Matchers, OneInstancePerTest, PrivateMethodTester}
 
-import scala.reflect.internal.util.{NoPosition, OffsetPosition}
+import scala.reflect.internal.util.NoPosition
 import scala.tools.nsc.reporters.StoreReporter
 
 /** @author Stephen Samuel */

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/WhileTrueTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/WhileTrueTest.scala
@@ -13,7 +13,7 @@ class WhileTrueTest extends FreeSpec with Matchers with PluginRunner with OneIns
     "when constant" - {
       "should report warning" in {
 
-        val code = """import scala.collection.JavaConversions._
+        val code = """
                     object Test {
                       while (true) {
                         println("sam")
@@ -27,7 +27,7 @@ class WhileTrueTest extends FreeSpec with Matchers with PluginRunner with OneIns
     "when not constant" - {
       "should not report warning" in {
 
-        val code = """import scala.collection.JavaConversions._
+        val code = """
                     object Test {
                       while (System.currentTimeMillis > 0) {
                         println("sam")
@@ -44,7 +44,7 @@ class WhileTrueTest extends FreeSpec with Matchers with PluginRunner with OneIns
     "when constant" - {
       "should report warning" in {
 
-        val code = """import scala.collection.JavaConversions._
+        val code = """
                     object Test {
                       do {
                         println("sam")
@@ -58,7 +58,7 @@ class WhileTrueTest extends FreeSpec with Matchers with PluginRunner with OneIns
     "when not constant" - {
       "should not report warning" in {
 
-        val code = """import scala.collection.JavaConversions._
+        val code = """
                     object Test {
                       do {
                         println("sam")

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/JavaConversionsUseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/JavaConversionsUseTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.{ PluginRunner, isScala213 }
 import org.scalatest.{ FreeSpec, Matchers }
 
 /** @author Stephen Samuel */
@@ -9,7 +9,7 @@ class JavaConversionsUseTest extends FreeSpec with Matchers with PluginRunner {
   override val inspections = Seq(new JavaConversionsUse)
 
   "JavaConversionsUse" - {
-    "should report warning" in {
+    "should report warning (for Scala < 2.13)" in {
 
       val code = """import scala.collection.JavaConversions._
                     object Test {
@@ -18,9 +18,10 @@ class JavaConversionsUseTest extends FreeSpec with Matchers with PluginRunner {
                       val a = jul.exists(_ == "sammy")
                    |  val b = jum.toSeq
                     } """.stripMargin
+      val expectedWarnings = if (isScala213) 0 else 1
 
       compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 1
+      compiler.scapegoat.feedback.warnings should have size expectedWarnings
     }
   }
 }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefSeqIsMutableTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefSeqIsMutableTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.{ PluginRunner, isScala213 }
 
 import org.scalatest.{ FreeSpec, Matchers, OneInstancePerTest }
 
@@ -10,16 +10,18 @@ class PredefSeqIsMutableTest extends FreeSpec with Matchers with PluginRunner wi
   override val inspections = Seq(new PredefSeqIsMutable)
 
   "PredefSeqUse" - {
-    "should report warning" - {
-      "for predef seq apply" in {
+    "should report warning (for Scala < 2.13)" - {
+      "for predef seq apply" in  {
         val code = """object Test { val a = Seq("sammy") }""".stripMargin
+        val expectedWarnings = if (isScala213) 0 else 1
         compileCodeSnippet(code)
-        compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compiler.scapegoat.feedback.warnings should have size expectedWarnings
       }
       "for declaring Seq as return type" in {
         val code = """object Test { def foo : Seq[String] = ??? }""".stripMargin
+        val expectedWarnings = if (isScala213) 0 else 1
         compileCodeSnippet(code)
-        compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compiler.scapegoat.feedback.warnings should have size expectedWarnings
       }
     }
     "should not report warning" - {

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefTraversableIsMutableTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefTraversableIsMutableTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.{ PluginRunner, isScala213 }
 import org.scalatest.{ FreeSpec, Matchers, OneInstancePerTest }
 
 /** @author Stephen Samuel */
@@ -9,16 +9,18 @@ class PredefTraversableIsMutableTest extends FreeSpec with Matchers with PluginR
   override val inspections = Seq(new PredefTraversableIsMutable)
 
   "PredefTraversableIsMutable" - {
-    "should report warning" - {
+    "should report warning (for Scala < 2.13)" - {
       "for predef Traversable apply" in {
         val code = """object Test { val a = Traversable("sammy") }""".stripMargin
+        val expectedWarnings = if (isScala213) 0 else 1
         compileCodeSnippet(code)
-        compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compiler.scapegoat.feedback.warnings should have size expectedWarnings
       }
       "for declaring Traversable as return type" in {
         val code = """object Test { def foo : Traversable[String] = ??? }""".stripMargin
+        val expectedWarnings = if (isScala213) 0 else 1
         compileCodeSnippet(code)
-        compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compiler.scapegoat.feedback.warnings should have size expectedWarnings
       }
     }
     "should not report warning" - {

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatchTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatchTest.scala
@@ -3,7 +3,6 @@ package com.sksamuel.scapegoat.inspections.matching
 import com.sksamuel.scapegoat.PluginRunner
 import org.scalatest.{ OneInstancePerTest, FreeSpec, Matchers }
 
-import scala.concurrent.Future
 
 /** @author Stephen Samuel */
 class PartialFunctionInsteadOfMatchTest

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/EmptyInterpolatedStringTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/EmptyInterpolatedStringTest.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.{ PluginRunner, isScala213 }
 import org.scalatest.{ FreeSpec, Matchers, OneInstancePerTest }
 
 /** @author Stephen Samuel */
@@ -9,15 +9,16 @@ class EmptyInterpolatedStringTest extends FreeSpec with Matchers with PluginRunn
   override val inspections = Seq(new EmptyInterpolatedString)
 
   "EmptyInterpolatedString" - {
-    "should report warning" in {
+    "should report warning (for Scala < 2.13)" in {
 
       val code = """object Test {
                       val name = "sam"
                       s"hello name"
                    } """.stripMargin
+      val expectedWarnings = if (isScala213) 0 else 1
 
       compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 1
+      compiler.scapegoat.feedback.warnings should have size expectedWarnings
     }
   }
   "non empty interpolated string" - {

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/NoOpOverrideTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/NoOpOverrideTest.scala
@@ -2,7 +2,6 @@ package com.sksamuel.scapegoat.inspections.unnecessary
 
 import com.sksamuel.scapegoat.PluginRunner
 import com.sksamuel.scapegoat.inspections.NoOpOverride
-import com.sksamuel.scapegoat.inspections.unneccesary.UnnecessaryToInt
 import org.scalatest.{ FreeSpec, Matchers, OneInstancePerTest }
 
 /** @author Stephen Samuel */


### PR DESCRIPTION
Scala 2.13 is finally available. :tada: 

Since we are using scapegoat in our projects, we need a release for 2.13.

This PR is migrating the inspections to 2.13 while keeping compatibility with 2.11 and 2.12.

*breaking changes*:

* String interpolations are no longer recognized, since they are macro expanded (see [FastStringInterpolator.scala:23](https://github.com/scala/scala/blob/f1dec97ed35ba60ef1489592f230a00ed7184545/src/compiler/scala/tools/reflect/FastStringInterpolator.scala#L23))
* `JavaConversions` are gone in 2.13, test code compilation fails with `object JavaConversions is not a member of package collection`
* `scala.Seq` is now aliased to `scala.collections.immutable.Seq` instead of `scala.collections.Seq` - makes the (ineptly named) `PredefSeqIsMutable` inspection obsolete
* `scala.Traversable` is now an alias for `scala.collection.Iterable` and it is deprecated - makes the `PredefTraversableIsMutable` obsolete