### PR TITLE
Remove use of existential types and Scapegoat types in typeOf

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
@@ -53,7 +53,6 @@ case class InspectionContext(global: Global, feedback: Feedback) {
     import global._
 
     private val SuppressWarnings = typeOf[SuppressWarnings]
-    private val Safe = typeOf[Safe]
 
     private def inspectionClass(klass: Class[_]): Class[_] = Option(klass.getEnclosingClass) match {
       case None    => klass
@@ -68,7 +67,11 @@ case class InspectionContext(global: Global, feedback: Feedback) {
       an.javaArgs.head._2.toString.toLowerCase.contains(inspectionClass(getClass).getSimpleName.toLowerCase)
     }
 
-    private def isSkipAnnotation(an: AnnotationInfo) = an.tree.tpe =:= SuppressWarnings || an.tree.tpe =:= Safe
+    private def isSkipAnnotation(an: AnnotationInfo) = {
+      // Workaround for #222: we can't use typeOf[Safe] here it requires Scapegoat to be on the
+      // compile classpath.
+      an.tree.tpe =:= SuppressWarnings || an.tree.tpe.erasure.toString == "com.sksamuel.scapegoat.Safe"
+    }
 
     private def isSuppressed(symbol: Symbol) = {
       symbol != null &&

--- a/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
@@ -97,6 +97,18 @@ case class InspectionContext(global: Global, feedback: Feedback) {
         case _ => inspect(tree)
       }
     }
+
+    protected def isArray(tree: Tree): Boolean = tree.tpe.typeSymbol.fullName == "scala.Array"
+    protected def isTraversable(tree: Tree): Boolean = tree.tpe <:< typeOf[Traversable[Any]]
+    protected def isSeq(t: Tree): Boolean = t.tpe <:< typeOf[Seq[Any]]
+    protected def isIndexedSeq(t: Tree): Boolean = t.tpe <:< typeOf[IndexedSeq[Any]]
+    protected def isSet(t: Tree): Boolean = {
+      t.tpe.widen.baseClasses.exists { c =>
+        c.fullName == "scala.collection.mutable.Set" || c.fullName == "scala.collection.immutable.Set"
+      }
+    }
+    protected def isList(t: Tree): Boolean = t.tpe <:< typeOf[scala.collection.immutable.List[Any]]
+    protected def isMap(tree: Tree): Boolean = tree.tpe.baseClasses.exists { _.fullName == "scala.collection.Map" }
   }
 }
 

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ArrayEquals.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ArrayEquals.scala
@@ -12,7 +12,7 @@ class ArrayEquals extends Inspection(
 
       import context.global._
 
-      private def isArray(tree: Tree) = tree match {
+      protected override def isArray(tree: Tree): Boolean = tree match {
         // "null" is deprecated, but comparing an array to null can be useful
         // in some cases (e.g. when interfacing with null-using Java code) and
         // shouldn't trigger this warning, which relates to whether the
@@ -22,7 +22,7 @@ class ArrayEquals extends Inspection(
         // be coerced to Array when it is compared to an array, so it would
         // otherwise match the next case.
         case Literal(Constant(null)) => false
-        case x                       => x.tpe <:< typeOf[Array[_]]
+        case x                       => super.isArray(x)
       }
 
       override def inspect(tree: Tree): Unit = {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/AvoidSizeEqualsZero.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/AvoidSizeEqualsZero.scala
@@ -15,7 +15,7 @@ class AvoidSizeEqualsZero extends Inspection("Avoid Traversable.size == 0, use T
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Apply(Select(Select(q, Size | Length), TermName("$eq$eq")), List(Literal(Constant(0)))) if q.tpe.<:<(typeOf[Traversable[_]]) =>
+          case Apply(Select(Select(q, Size | Length), TermName("$eq$eq")), List(Literal(Constant(0)))) if isTraversable(q) =>
             context.warn(tree.pos, self,
               "Traversable.size is slow for some implementations. Prefer .isEmpty which is O(1): " + tree.toString().take(100))
           case _ => continue(tree)

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionIndexOnNonIndexedSeq.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionIndexOnNonIndexedSeq.scala
@@ -11,8 +11,6 @@ class CollectionIndexOnNonIndexedSeq extends Inspection(
 
       import context.global._
 
-      private def isSeq(t: Tree) = t.tpe <:< typeOf[Seq[Any]]
-      private def isIndexedSeq(t: Tree) = t.tpe <:< typeOf[IndexedSeq[Any]]
       private def isLiteral(t: Tree) = t match {
         case Literal(_) => true
         case _ => false

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNamingConfusion.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNamingConfusion.scala
@@ -12,16 +12,14 @@ class CollectionNamingConfusion extends Inspection("Collection naming Confusion"
 
       private def isNamedSet(name: String): Boolean = name.trim == "set" || name.trim.contains("Set")
       private def isNamedList(name: String): Boolean = name.trim == "list" || name.trim.contains("List")
-      private def isSet(tpe: Type) = tpe <:< typeOf[scala.collection.mutable.Set[_]] || tpe <:< typeOf[scala.collection.immutable.Set[_]]
-      private def isList(tpe: Type) = tpe <:< typeOf[scala.collection.immutable.List[_]]
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case ValDef(_, TermName(name), tpt, _) if isSet(tpt.tpe) && isNamedList(name) =>
+          case ValDef(_, TermName(name), tpt, _) if isSet(tpt) && isNamedList(name) =>
             context.warn(tree.pos, self,
               "An instance of Set is confusingly referred to by a variable called/containing list: " +
                 tree.toString().take(300))
-          case v @ ValDef(_, TermName(name), tpt, _) if isList(tpt.tpe) && isNamedSet(name) =>
+          case v @ ValDef(_, TermName(name), tpt, _) if isList(tpt) && isNamedSet(name) =>
             context.warn(tree.pos, self,
               "An instance of List is confusingly referred to by a variable called/containing set: " +
                 tree.toString().take(300))

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNegativeIndex.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNegativeIndex.scala
@@ -12,7 +12,7 @@ class CollectionNegativeIndex extends Inspection("Collection index out of bounds
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Apply(Select(lhs, TermName("apply")), List(Literal(Constant(x: Int)))) if lhs.tpe <:< typeOf[List[_]] && x < 0 =>
+          case Apply(Select(lhs, TermName("apply")), List(Literal(Constant(x: Int)))) if isList(lhs) && x < 0 =>
             context.warn(tree.pos, self, tree.toString().take(100))
           case _ => continue(tree)
         }

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
@@ -16,8 +16,6 @@ class ExistsSimplifiableToContains extends Inspection("Exists simplifiable to co
 
       private val Equals = TermName("$eq$eq")
 
-      private def isTraversable(tree: Tree) = tree.tpe <:< typeOf[Traversable[Any]]
-
       private def isContainsType(container: Tree, value: Tree): Boolean = {
         val valueType = value.tpe.underlying.typeSymbol.tpe
         val traversableType = container.tpe.underlying.baseType(typeOf[Traversable[Any]].typeSymbol)

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ListAppend.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ListAppend.scala
@@ -11,7 +11,6 @@ class ListAppend extends Inspection("List append is slow", Levels.Info,
 
       import context.global._
 
-      private def isList(tree: Tree) = tree.tpe <:< typeOf[List[_]]
       private val Append = TermName("$colon$plus")
 
       override def inspect(tree: Tree): Unit = {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ListSize.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ListSize.scala
@@ -13,7 +13,7 @@ class ListSize extends Inspection("List.size is O(n)", Levels.Info,
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Select(lhs, TermName("size")) if lhs.tpe <:< typeOf[List[_]] =>
+          case Select(lhs, TermName("size")) if isList(lhs) =>
             context.warn(tree.pos, self)
           case _ => continue(tree)
         }

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElse.scala
@@ -15,8 +15,6 @@ class MapGetAndGetOrElse extends Inspection("Use of .get.getOrElse instead of .g
 
       import context.global._
 
-      private def isMap(tree: Tree): Boolean = tree.tpe <:< typeOf[scala.collection.Map[_, _]]
-
       override def inspect(tree: Tree): Unit = {
         tree match {
           case Apply(TypeApply(Select(Apply(Select(left, TermName("get")), List(key)),

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/NegationIsEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/NegationIsEmpty.scala
@@ -12,7 +12,6 @@ class NegationIsEmpty extends Inspection("!isEmpty can be replaced with nonEmpty
 
       private val IsEmpty = TermName("isEmpty")
       private val Bang = TermName("unary_$bang")
-      private def isTraversable(tree: Tree) = tree.tpe <:< typeOf[Traversable[_]]
 
       override def inspect(tree: Tree): Unit = {
         tree match {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/NegationNonEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/NegationNonEmpty.scala
@@ -12,7 +12,6 @@ class NegationNonEmpty extends Inspection("!nonEmpty can be replaced with isEmpt
 
       private val IsEmpty = TermName("nonEmpty")
       private val Bang = TermName("unary_$bang")
-      private def isTraversable(tree: Tree) = tree.tpe <:< typeOf[Traversable[_]]
 
       override def inspect(tree: Tree): Unit = {
         tree match {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTailReverse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTailReverse.scala
@@ -11,7 +11,7 @@ class ReverseTailReverse extends Inspection("reverse.tail.reverse instead of ini
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Select(Select(Select(c, TermName("reverse")), TermName("tail")), TermName("reverse")) if c.tpe.<:<(typeOf[Traversable[_]]) =>
+          case Select(Select(Select(c, TermName("reverse")), TermName("tail")), TermName("reverse")) if isTraversable(c) =>
             warn(tree)
           case Select(Apply(arrayOps0, List(Select(Apply(arrayOps1, List(Select(Apply(arrayOps2, List(col)), TermName("reverse")))), TermName("tail")))), TermName("reverse")) if (arrayOps0.toString.contains("ArrayOps"))
             && arrayOps1.toString.contains("ArrayOps")

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTakeReverse.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTakeReverse.scala
@@ -11,7 +11,7 @@ class ReverseTakeReverse extends Inspection("reverse.take(...).reverse instead o
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Select(Apply(Select(Select(c, TermName("reverse")), TermName("take")), _), TermName("reverse")) if c.tpe.<:<(typeOf[Traversable[_]]) =>
+          case Select(Apply(Select(Select(c, TermName("reverse")), TermName("take")), _), TermName("reverse")) if isTraversable(c) =>
             warn(tree)
           case Select(Apply(arrayOps0, List(Apply(Select(Apply(arrayOps1, List(Select(Apply(arrayOps2, List(col)), TermName("reverse")))), TermName("take")), _))), TermName("reverse")) if (arrayOps0.toString.contains("ArrayOps"))
             && (arrayOps1.toString.contains("ArrayOps"))

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/SwapSortFilter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/SwapSortFilter.scala
@@ -10,9 +10,6 @@ class SwapSortFilter extends Inspection("Swap sort filter", Levels.Info) {
 
       import context.global._
 
-      private val Seq = typeOf[Seq[_]]
-      private def isSeq(tree: Tree) = tree.tpe <:< Seq
-
       override def inspect(tree: Tree): Unit = {
         tree match {
           case Apply(Select(Apply(TypeApply(Select(lhs, TermName("sorted")), _), _), TermName("filter")), _) if isSeq(lhs) =>

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/TraversableHead.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/TraversableHead.scala
@@ -13,7 +13,7 @@ class TraversableHead extends Inspection("Use of Traversable.head", Levels.Error
       override def inspect(tree: Tree): Unit = {
         tree match {
           case Select(left, TermName("head")) =>
-            if (left.tpe <:< typeOf[Traversable[_]])
+            if (isTraversable(left))
               context.warn(tree.pos, self, tree.toString().take(500))
           case _ => continue(tree)
         }

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/TraversableLast.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/TraversableLast.scala
@@ -12,7 +12,7 @@ class TraversableLast extends Inspection("Use of Traversable.last", Levels.Error
       override def inspect(tree: Tree): Unit = {
         tree match {
           case Select(left, TermName("last")) =>
-            if (left.tpe <:< typeOf[Traversable[_]])
+            if (isTraversable(left))
               context.warn(tree.pos, self, tree.toString().take(500))
           case _ => continue(tree)
         }

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeContains.scala
@@ -11,8 +11,8 @@ class UnsafeContains extends Inspection("Unsafe contains", Levels.Error) {
       import treeInfo.Applied
 
       private val Contains = TermName("contains")
-      private val Seq = typeOf[Seq[_]].typeSymbol
-      private val Option = typeOf[Option[_]].typeSymbol
+      private val Seq = typeOf[Seq[Any]].typeSymbol
+      private val Option = typeOf[Option[Any]].typeSymbol
       private def isSeqOrOption(tree: Tree): Boolean = {
         val baseClasses = tree.tpe.widen.baseClasses
         baseClasses.contains(Seq) || baseClasses.contains(Option)

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/ArraysInFormat.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/ArraysInFormat.scala
@@ -10,7 +10,7 @@ class ArraysInFormat extends Inspection("Array passed to String.format", Levels.
 
       import context.global._
 
-      private def containsArrayType(trees: List[Tree]) = trees.exists(_.tpe <:< typeOf[Array[_]])
+      private def containsArrayType(trees: List[Tree]) = trees.exists(isArray)
 
       override def inspect(tree: Tree): Unit = {
         tree match {

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/ArraysToString.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/ArraysToString.scala
@@ -11,7 +11,6 @@ class ArraysToString extends Inspection("Use of Array.toString", Levels.Warning)
       import context.global._
 
       private val ToString = TermName("toString")
-      private def isArray(tree: Tree) = tree.tpe <:< typeOf[Array[_]]
 
       override def inspect(tree: Tree): Unit = {
         tree match {


### PR DESCRIPTION
This PR removes all uses of existential types and Scapegoat types in `typeOf[]`. If Scapegoat classes are not on the compile classpath then these `typeOf`s caused `scala.ScalaReflectionException: object <type> in compiler mirror not found` exceptions during compilation (see #222, #167, #163, #98).

To do this, I added several `is<type>(tree: Tree)` helper methods to the `InspectionContext.Traverser` trait. There's a couple of details which I'll discuss in PR self-review comments.

I tested this by integrating Scapegoat into a Bazel build.

Fixes #222.