### PR TITLE
Improve SuppressWarnings support to work for all members

### DIFF
--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/TraversableHeadTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/TraversableHeadTest.scala
@@ -21,6 +21,73 @@ class TraversableHeadTest extends FreeSpec with Matchers with PluginRunner with 
       compileCodeSnippet(code)
       compiler.scapegoat.feedback.warnings.size shouldBe 4
     }
+    "should suppress warnings when SuppressWarnings specified with all" in {
+
+      val code = """@SuppressWarnings(Array("all"))
+                    class Test {
+                      Seq("sam").head
+                      List("sam").head
+                      Vector("sam").head
+                      Iterable("sam").head
+                    } """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+    "should suppress warnings when SuppressWarnings specified with name" in {
+
+      val code = """@SuppressWarnings(Array("TraversableHead"))
+                    class Test {
+                      Seq("sam").head
+                      List("sam").head
+                      Vector("sam").head
+                      Iterable("sam").head
+                    } """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+
+    "should suppress val-level warnings when SuppressWarnings specified with all" in {
+      val code = """class Test {
+                      @SuppressWarnings(Array("all"))
+                      val a : String = List("sam").head
+                    } """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+
+    "should suppress val-level warnings when SuppressWarnings specified with name" in {
+      val code = """class Test {
+                      @SuppressWarnings(Array("TraversableHead"))
+                      val a : String = List("sam").head
+                    } """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+
+    "should suppress def-level warnings when SuppressWarnings specified with all" in {
+      val code = """class Test {
+                      @SuppressWarnings(Array("all"))
+                      def a : String = List("sam").head
+                    } """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+
+    "should suppress def-level warnings when SuppressWarnings specified with name" in {
+      val code = """class Test {
+                      @SuppressWarnings(Array("TraversableHead"))
+                      def a : String = List("sam").head
+                    } """.stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+
     "should not report warning" - {
       "for var args" in {
         val code = """class F(args:String*)""".stripMargin


### PR DESCRIPTION
This PR makes the `SuppressWarnings` annotation work more broadly. It should now be possible to annotate any member of a structure (including `val` members, which were the initial problem I was trying to solve). I added some tests for the new functionality to the `TraversableHeadTest` because I didn't see a test class specific to the warning suppression.

I also refactored the `isThisDisabled` method a bit (and merged the `isAllDisabled` functionality into it) to destructure the annotation arguments rather than relying on string processing, which should prevent false positives due to an unexpected substring match. I made it so users can also specify the full canonical class name when listing classes to suppress.