### PR TITLE
Embed shaded scala-xml and scala-collection-compat modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,10 +77,14 @@ def check(code: String) = {
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 libraryDependencies ++= Seq(
-  "org.scala-lang"                  %     "scala-reflect"           % scalaVersion.value,
+  "org.scala-lang"                  %     "scala-reflect"           % scalaVersion.value      % "provided",
   "org.scala-lang"                  %     "scala-compiler"          % scalaVersion.value      % "provided",
-  "org.scala-lang.modules"          %%    "scala-xml"               % "1.2.0",
-  "org.scala-lang.modules"          %%    "scala-collection-compat" % "2.0.0",
+  "org.scala-lang.modules"          %%    "scala-xml"               % "1.2.0" excludeAll(
+    ExclusionRule(organization = "org.scala-lang")
+  ),
+  "org.scala-lang.modules"          %%    "scala-collection-compat" % "2.1.2" excludeAll(
+    ExclusionRule(organization = "org.scala-lang")
+  ),
   "org.scala-lang"                  %     "scala-compiler"          % scalaVersion.value      % "test",
   "commons-io"                      %     "commons-io"              % "2.5"                   % "test",
   "org.scalatest"                   %%    "scalatest"               % "3.0.8"                 % "test",
@@ -132,3 +136,19 @@ pomExtra := {
       </developer>
     </developers>
 }
+
+// include the scala xml and compat modules into the final jar, shaded
+assemblyShadeRules in assembly := Seq(
+  ShadeRule.rename("scala.xml.**" -> "scapegoat.xml.@1").inAll,
+  ShadeRule.rename("scala.collection.compat.**" -> "scapegoat.compat.@1").inAll
+)
+
+// do not run tests during assembly
+test in assembly := {}
+
+autoScalaLibrary := false
+makePom := makePom.dependsOn(assembly).value
+packageBin in Compile := crossTarget.value / (assemblyJarName in assembly).value
+
+// debug assembly process
+//logLevel in assembly := Level.Debug

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ resolvers += Classpaths.sbtPluginReleases
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")


### PR DESCRIPTION
Starting with Scala 2.13, the scala-xml is no longer included in the
distribution and no longer automatically available on the compiler's classpath.

Furthermore, in Scala < 2.13, the compiler did provide the module on the
classpath, but you could not choose which version.

As it seems, there is currently no way to add dependencies to the compiler's classpath.

Fixes sksamuel/sbt-scapegoat#91.

[previously](https://stackoverflow.com/questions/24972955/sbt-plugin-add-dependency-to-project-build-sbt)