### PR TITLE
Output filtering by level of inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ You can pass other configuration flags adding it to the `additionalParameters` l
 |`-P:scapegoat:reports:`|Colon separated list of reports to generate. Valid options are `none`, `xml`, `html`, `scalastyle`, or `all`.|false|
 |`-P:scapegoat:overrideLevels:`|Overrides the built in warning levels. Should be a colon separated list of `name=level` expressions.|false|
 |`-P:scapegoat:sourcePrefix:`|Overrides source prefix if it differs from `src/main/scala`, for ex. `app/` for Play applications.|false|
+|`-P:scapegoat:minimalWarnLevel:`|Provides minimal level of inspection displayed in reports.|false|
 
 ### Reports
 

--- a/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/HtmlReportWriter.scala
@@ -89,7 +89,7 @@ object HtmlReportWriter {
     </body>
 
   def warnings(reporter: Feedback) = {
-    reporter.warnings.map {
+    reporter.warningsWithMinimalLevel.map {
       case warning =>
         val source = warning.sourceFileNormalized + ":" + warning.line
         <div class="warning">

--- a/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/ScalastyleReportWriter.scala
@@ -12,7 +12,7 @@ object ScalastyleReportWriter {
 
   def toXML(feedback: Feedback): Node = {
     <checkstyle version={ checkstyleVersion } generatedBy={ scapegoat }>
-      { feedback.warnings.groupBy(_.sourceFileFull).map(fileToXml) }
+      { feedback.warningsWithMinimalLevel.groupBy(_.sourceFileFull).map(fileToXml) }
     </checkstyle>
   }
 

--- a/src/main/scala/com/sksamuel/scapegoat/io/XmlReportWriter.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/io/XmlReportWriter.scala
@@ -9,7 +9,7 @@ object XmlReportWriter {
 
   def toXML(feedback: Feedback): Node = {
     <scapegoat count={ feedback.warnings.size.toString } warns={ feedback.warns.size.toString } errors={ feedback.errors.size.toString } infos={ feedback.infos.size.toString }>
-      { feedback.warnings.map(warning2xml) }
+      { feedback.warningsWithMinimalLevel.map(warning2xml) }
     </scapegoat>
   }
 

--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -17,22 +17,22 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
   override val components: List[PluginComponent] = List(component)
 
   override def init(options: List[String], error: String => Unit): Boolean = {
-    options.find(_.startsWith("disabledInspections:")) match {
+    forProperty("disabledInspections:") match {
       case Some(option) => component.disabled = option.drop("disabledInspections:".length).split(':').toList
       case _            =>
     }
-    options.find(_.startsWith("consoleOutput:")) match {
+    forProperty("consoleOutput:") match {
       case Some(option) => component.consoleOutput = option.drop("consoleOutput:".length).toBoolean
       case _            =>
     }
-    options.find(_.startsWith("ignoredFiles:")) match {
+    forProperty("ignoredFiles:") match {
       case Some(option) => component.ignoredFiles = option.drop("ignoredFiles:".length).split(':').toList
       case _            =>
     }
-    for (verbose <- options.find(_.startsWith("verbose:"))) {
+    for (verbose <- forProperty("verbose:")) {
       component.verbose = verbose.drop("verbose:".length).toBoolean
     }
-    options.find(_.startsWith("customInspectors:")) match {
+    forProperty("customInspectors:") match {
       case Some(option) => component.customInpections =
         option.drop("customInspectors:".length)
           .split(':')
@@ -40,7 +40,7 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
           .map(inspection => Class.forName(inspection).getConstructor().newInstance().asInstanceOf[Inspection])
       case _ =>
     }
-    options.find(_.startsWith("reports:")) match {
+    forProperty("reports:") match {
       case Some(option) =>
         option.drop("reports:".length)
           .split(':')
@@ -64,7 +64,7 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
         component.disableHTML = false
         component.disableScalastyleXML = false
     }
-    options.find(_.startsWith("overrideLevels:")) foreach {
+    forProperty("overrideLevels:") foreach {
       case option =>
         component.feedback.levelOverridesByInspectionSimpleName =
           option.drop("overrideLevels:".length).split(":").map {
@@ -80,19 +80,19 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
               }
           }.toMap
     }
-    options.find(_.startsWith("sourcePrefix:")) match {
+    forProperty("sourcePrefix:") match {
       case Some(option) => {
         component.sourcePrefix = option.drop("sourcePrefix:".length)
       }
       case None => component.sourcePrefix = "src/main/scala/"
     }
-    options.find(_.startsWith("minimalLevel:")) match {
+    forProperty("minimalLevel:") match {
       case Some(level) => {
         component.minimalLevel = Levels.fromName(level)
       }
       case None => component.minimalLevel = Levels.Info
     }
-    options.find(_.startsWith("dataDir:")) match {
+    forProperty("dataDir:") match {
       case Some(option) =>
         component.dataDir = new File(option.drop("dataDir:".length))
         true
@@ -126,6 +126,9 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
     "                                                     'level' is the simple name of a",
     "                                                     com.sksamuel.scapegoat.Level constant, e.g. 'Warning'.")
     .mkString("\n"))
+
+  private def forProperty(name: String): Option[String] =
+    options.find(_.startsWith(name))
 }
 
 class ScapegoatComponent(val global: Global, inspections: Seq[Inspection])

--- a/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
@@ -70,5 +70,41 @@ class FeedbackTest
         result should ===("com.sksamuel.scapegoat.Test.scala")
       }
     }
+    "should use minimal wawrning level in reports" - {
+      "for `info`" in {
+        val inspectionError = new DummyInspection("My default is Error", Levels.Error)
+        val inspectionWarning = new DummyInspection("My default is Warning", Levels.Warning)
+        val inspectionInfo = new DummyInspection("My default is Info", Levels.Info)
+        val inspections = Seq(inspectionError, inspectionWarning, inspectionInfo)
+        val reporter = new StoreReporter
+        val feedback = new Feedback(false, reporter, defaultSourcePrefix, Levels.Info)
+        inspections.foreach(inspection => feedback.warn(position, inspection))
+        feedback.warningsWithMinimalLevel.length should be(3)
+      }
+
+      "for `warning`" in {
+        val inspectionError = new DummyInspection("My default is Error", Levels.Error)
+        val inspectionWarning = new DummyInspection("My default is Warning", Levels.Warning)
+        val inspectionInfo = new DummyInspection("My default is Info", Levels.Info)
+        val inspections = Seq(inspectionError, inspectionWarning, inspectionInfo)
+        val reporter = new StoreReporter
+        val feedback = new Feedback(false, reporter, defaultSourcePrefix, Levels.Warning)
+        inspections.foreach(inspection => feedback.warn(position, inspection))
+        feedback.warningsWithMinimalLevel.length should be(2)
+        feedback.warningsWithMinimalLevel.map(_.level) should contain only(Seq(Levels.Warning, Levels.Error): _*)
+      }
+
+      "for `error`" in {
+        val inspectionError = new DummyInspection("My default is Error", Levels.Error)
+        val inspectionWarning = new DummyInspection("My default is Warning", Levels.Warning)
+        val inspectionInfo = new DummyInspection("My default is Info", Levels.Info)
+        val inspections = Seq(inspectionError, inspectionWarning, inspectionInfo)
+        val reporter = new StoreReporter
+        val feedback = new Feedback(false, reporter, defaultSourcePrefix, Levels.Error)
+        inspections.foreach(inspection => feedback.warn(position, inspection))
+        feedback.warningsWithMinimalLevel.length should be(1)
+        feedback.warningsWithMinimalLevel.map(_.level) should contain only(Seq(Levels.Error): _*)
+      }
+    }
   }
 }

--- a/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
@@ -8,7 +8,6 @@ import scala.tools.nsc.reporters.ConsoleReporter
 
 /**
  * @author Stephen Samuel
- * @author Eugene Sypachev (Axblade)
  */
 trait PluginRunner {
 


### PR DESCRIPTION
refs #181

It adds `minimalLevel` property, that defaults to `Levels.Info`.
Also, the -Pscapegoat:minimalLevel:<level> compiler option is added.

If specified, the output will be filtered by level, for ex. if it is set to `warning`, only warnings and errors will be displayed in the reports. Triggered inspections count is not affected by this change, all numbers will be visible in HTML report.