### PR TITLE
Better compiler flag description

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,21 @@ The only required parameter is `dataDir` (where report will be generated):
 
 You can pass other configuration flags adding it to the `additionalParameters` list, e.g.
 
-`"-P:scapegoat:disabledInspections:FinalModifierOnCaseClass""`
+`"-P:scapegoat:disabledInspections:FinalModifierOnCaseClass"`
 
+#### Full list of compiler flags
+
+| Flag | Parameters | Required |
+|------|------------|----------|
+|`-P:scapegoat:dataDir:`|Path to reports directory for the plugin.|true|
+|`-P:scapegoat:disabled:`|Colon separated list of disabled inspections.|false|
+|`-P:scapegoat:customInspectors:`|Colon separated list of custom inspections.|false|
+|`-P:scapegoat:ignoredFiles:`|Colon separated list of regexes to match files to ignore.|false|
+|`-P:scapegoat:verbose:`|Boolean flag that enables/disables verbose console messages.|false|
+|`-P:scapegoat:consoleOutput:`|Boolean flag that enables/disables console report output.|false|
+|`-P:scapegoat:reports:`|Colon separated list of reports to generate. Valid options are `none`, `xml`, `html`, `scalastyle`, or `all`.|false|
+|`-P:scapegoat:overrideLevels:`|Overrides the built in warning levels. Should be a colon separated list of `name=level` expressions.|false|
+|`-P:scapegoat:sourcePrefix:`|Overrides source prefix if it differs from `src/main/scala`, for ex. `app/` for Play applications.|false|
 
 ### Reports
 

--- a/src/test/scala/com/sksamuel/scapegoat/ReadmeTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/ReadmeTest.scala
@@ -12,6 +12,8 @@ class ReadmeTest extends FreeSpec with Matchers {
     readme
       .dropWhile(l => l.trim.distinct != "|-")
       .drop(1)
+      .dropWhile(l => l.trim.distinct != "|-")
+      .drop(1)
       .takeWhile(l => l.trim.nonEmpty)
       .map(_.split("\\|"))
       .collect {


### PR DESCRIPTION
This PR adds more details about command line flags in the readme.
It might be useful if we build GH-pages for the project.