### PR TITLE
Providing support for enabledInspections

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ You can pass other configuration flags adding it to the `additionalParameters` l
 | Flag | Parameters | Required |
 |------|------------|----------|
 |`-P:scapegoat:dataDir:`|Path to reports directory for the plugin.|true|
-|`-P:scapegoat:disabled:`|Colon separated list of disabled inspections.|false|
+|`-P:scapegoat:disabledInspections:`|Colon separated list of disabled inspections (defaults to none).|false|
+|`-P:scapegoat:enabledInspections:`|Colon separated list of enabled inspections (defaults to all).|false|
 |`-P:scapegoat:customInspectors:`|Colon separated list of custom inspections.|false|
 |`-P:scapegoat:ignoredFiles:`|Colon separated list of regexes to match files to ignore.|false|
 |`-P:scapegoat:verbose:`|Boolean flag that enables/disables verbose console messages.|false|


### PR DESCRIPTION
Currently you can disable (black list) some inspections. What would be useful if you could start from empty set of inspections and gradually add (white list) some of them.
Thus adding support for `-P:scapegoat:enabledInspections` argument with same syntax.

I find it a blocker for adoption at a large code base where I don't stand a chance to fix all the bugs / code smells in one go.

Also fixing an inconsistency, the help text incorrectly mentioned `disabled` as existing argument name while it's `disabledInspections`.

### Testing
- sadly no UT coverage
- I've tested by executing in a Maven profile, with and without the new argument. Subsequently I saw tons and a few failures reported. As expected.