### PR TITLE
[minor] Fixing syntax warnings

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseSqrt.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/math/UseSqrt.scala
@@ -21,7 +21,6 @@ class UseSqrt extends Inspection("Use sqrt", Levels.Info) {
             context.warn(tree.pos, self,
               s"$math.sqrt is clearer and more performant than $math.pow(x, 0.5)")
           case other =>
-            other
             continue(tree)
         }
       }

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/option/OptionSize.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/option/OptionSize.scala
@@ -12,10 +12,10 @@ class OptionSize extends Inspection("Prefer Option.isDefined instead of Option.s
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Select(Apply(option2Iterable, List(opt)), TermName("size")) ⇒
+          case Select(Apply(option2Iterable, List(opt)), TermName("size")) =>
             if (option2Iterable.symbol.fullName == "scala.Option.option2Iterable")
               context.warn(tree.pos, self, tree.toString().take(500))
-          case _ ⇒ continue(tree)
+          case _ => continue(tree)
         }
       }
     }


### PR DESCRIPTION
Minor contribution. Fixing compiler warnings:
- syntax for `=>` in 2.13
- and useless expression