### PR TITLE
False positive: `%n` String format

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormat.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormat.scala
@@ -14,12 +14,16 @@ class IncorrectNumberOfArgsToFormat extends Inspection("Incorrect number of args
 
       import context.global._
 
+      private def doesNotTakeArguments(formatSpecifier: String) = {
+        formatSpecifier == "%%" || formatSpecifier == "%n"
+      }
+
       override def inspect(tree: Tree): Unit = {
         tree match {
           case Apply(Select(Apply(Select(_, TermName("augmentString")), List(Literal(Constant(format)))),
             TermName("format")), args) =>
             // %% doesn't consume any arguments, but all other formats do
-            val argCount = argRegex.findAllIn(format.toString).matchData.filterNot(_.matched == "%%").size
+            val argCount = argRegex.findAllIn(format.toString).matchData.filterNot(m => doesNotTakeArguments(m.matched)).size
             if (argCount > args.size)
               context.warn(tree.pos, self, tree.toString().take(500))
           case _ => continue(tree)

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormatTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormatTest.scala
@@ -42,6 +42,11 @@ class IncorrectNumberOfArgsToFormatTest extends FreeSpec with Matchers with Plug
         compileCodeSnippet(code3)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+      "for correct number of args when %n is used" in {
+        val code1 = """object Test {    "Hello %s%n".format("World")  }  """
+        compileCodeSnippet(code1)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
     }
   }
 }


### PR DESCRIPTION
`%n` is a valid String format specifier which doesn't take arguments, it stands for line separator as per [Javadoc](https://docs.oracle.com/javase/9/docs/api/java/util/Formatter.html#syntax):

>>> 'n'
>>> The conversion does not correspond to any argument. 
>>> the platform-specific line separator as returned by System.lineSeparator().


