### PR TITLE
Support for `all` in overrideLevels

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -24,7 +24,11 @@ class Feedback(consoleOutput: Boolean, reporter: Reporter, sourcePrefix: String,
     val level = inspection.defaultLevel
     val text = inspection.text
     val snippetText = inspection.explanation.orElse(snippet)
-    val adjustedLevel = levelOverridesByInspectionSimpleName.getOrElse(inspection.getClass.getSimpleName, level)
+    val adjustedLevel = (levelOverridesByInspectionSimpleName.get("all"), levelOverridesByInspectionSimpleName.get(inspection.getClass.getSimpleName)) match {
+      case (Some(l), _) => l
+      case (None, Some(l)) => l
+      case _ => level
+    }
 
     val sourceFileFull = pos.source.file.path
     val sourceFileNormalized = normalizeSourceFile(sourceFileFull)

--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -119,6 +119,7 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
     "                                                     settings, where 'name' is the simple name of an inspection",
     "                                                     and 'level' is the simple name of a",
     "                                                     com.sksamuel.scapegoat.Level constant, e.g. 'Warning'.",
+    "                                                     You can use 'all' for inspection name to operate on all inspections.",
     "-P:scapegoat:sourcePrefix:<prefix>                   overrides source prefix if it differs from src/main/scala",
     "                                                     for ex., in Play applications where sources are in app/ folder",
     "-P:scapegoat:minimalWarnLevel:<level>                provides minimal level of triggered inspections,",


### PR DESCRIPTION
Fixes #247 by providing a possibility to set an override for `all` inspection, e.g.
>  -P:scapegoat:overrideLevels:all=Error

Tested by running a Maven build with this setting and observing all the reported failures to be Errors in `xml` and `stdout` output. 
