### PR TITLE
Publish with full Scala version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,15 @@ jdk:
 before_script:
  - "echo $JAVA_OPTS"
  - "export JAVA_OPTS=-Xmx1024m"
+
+before_cache:
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.sbt -name "*.lock" -delete
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+
+# These directories are cached to S3 at the end of the build
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt/boot/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: scala
 scala:
+   - 2.11.12
    - 2.12.8
+   - 2.12.9
+   - 2.12.10
+   - 2.13.0
+   - 2.13.1
 script:
-   - sbt ++$TRAVIS_SCALA_VERSION clean test
+   - sbt clean test
 jdk:
    - oraclejdk11
 before_script:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ You can pass other configuration flags adding it to the `additionalParameters` l
 | Flag | Parameters | Required |
 |------|------------|----------|
 |`-P:scapegoat:dataDir:`|Path to reports directory for the plugin.|true|
-|`-P:scapegoat:disabled:`|Colon separated list of disabled inspections.|false|
+|`-P:scapegoat:disabledInspections:`|Colon separated list of disabled inspections (defaults to none).|false|
+|`-P:scapegoat:enabledInspections:`|Colon separated list of enabled inspections (defaults to all).|false|
 |`-P:scapegoat:customInspectors:`|Colon separated list of custom inspections.|false|
 |`-P:scapegoat:ignoredFiles:`|Colon separated list of regexes to match files to ignore.|false|
 |`-P:scapegoat:verbose:`|Boolean flag that enables/disables verbose console messages.|false|

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Firstly you need to add scapegoat plugin as a dependency:
 ```xml
 <dependency>
     <groupId>com.sksamuel.scapegoat</groupId>
-    <artifactId>scalac-scapegoat-plugin_${scala.binary.version}</artifactId>
-    <version>1.3.3</version>
+    <artifactId>scalac-scapegoat-plugin_${scala.version}</artifactId>
+    <version>1.3.12</version>
 </dependency>
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,12 @@ name := "scalac-scapegoat-plugin"
 
 organization := "com.sksamuel.scapegoat"
 
-scalaVersion := "2.12.8"
-crossScalaVersions := Seq("2.11.12", "2.13.0", scalaVersion.value)
+crossVersion := CrossVersion.full
+crossTarget := {
+  // workaround for https://github.com/sbt/sbt/issues/5097
+  target.value / s"scala-${scalaVersion.value}"
+}
+releaseCrossBuild := true
 
 sbtVersion in Global := "1.1.6"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+
+addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")

--- a/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
@@ -12,8 +12,7 @@ import scala.tools.nsc.reporters.ConsoleReporter
 trait PluginRunner {
 
   val scalaVersion = util.Properties.versionNumberString
-  val shortScalaVersion = scalaVersion.split('.').dropRight(1).mkString(".")
-
+ 
   val classPath = getScalaJars.map(_.getAbsolutePath) :+ sbtCompileDir.getAbsolutePath
 
   val settings = {
@@ -74,7 +73,7 @@ trait PluginRunner {
   }
 
   def sbtCompileDir: File = {
-    val dir = new File("./target/scala-" + shortScalaVersion + "/classes")
+    val dir = new File("./target/scala-" + scalaVersion + "/classes")
     if (dir.exists) dir
     else throw new FileNotFoundException(s"Could not locate SBT compile directory for plugin files [$dir]")
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.12-SNAPSHOT"
+version in ThisBuild := "1.4.0-SNAPSHOT"


### PR DESCRIPTION
As a rule of thumb, a scalac plugin always should be published using the full
scala version in its name, since scalac's internal APIs can change without notice.

This change introduces the sbt-travisci plugin which makes it easier to
maintain a full set of versions, cross compiled and run through the CI.

Fixes #248.