### PR TITLE
False positive: while varcouldbeval

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/VarCouldBeVal.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/unneccesary/VarCouldBeVal.scala
@@ -37,6 +37,7 @@ class VarCouldBeVal extends Inspection("Var could be val", Levels.Warning) {
             containsUnwrittenVar(body, vars)
           case ModuleDef(_, _, Template(_, _, body)) => containsUnwrittenVar(body, vars)
           case If(cond, thenp, elsep) =>
+            unwrittenVars(cond, vars)
             unwrittenVars(thenp, vars)
             unwrittenVars(elsep, vars)
           case tree =>

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/VarCouldBeValTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/VarCouldBeValTest.scala
@@ -170,6 +170,28 @@ class VarCouldBeValTest
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+      "when var is written to inside a while condition " in {
+
+        val code =
+          """package com.sammy
+            |object Test {
+            |def something(): List[String] = List("a")
+            |def test(): Unit = {
+            |  var items = List.empty[String]
+            |  while ({
+            |   items = something()
+            |   items.size
+            |  } < 10) {
+            |    println(items)
+            |  }
+            |}
+            |}""".stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+
+
       "when var is written to for nested defs" in {
         val code =
           """


### PR DESCRIPTION
Fixing `VarCouldBeVal` false positives for code which modifies the var reference in `while(...) {}` condition (not the body). I guess it fixes the `if (...) {}` situations too.
