### PR TITLE
False positive: suggests Set.empty() for mutable Sets

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferSetEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferSetEmpty.scala
@@ -15,10 +15,11 @@ class PreferSetEmpty extends Inspection("Prefer Set.empty", Levels.Info) {
 
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Apply(TypeApply(Select(Select(_, SetTerm), ApplyTerm), _), List()) =>
-            context.warn(tree.pos, self,
-              "Set[T]() creates a new instance. Consider Set.empty which does not allocate a new object. " +
-                tree.toString().take(500))
+          case a@Apply(TypeApply(Select(Select(_, SetTerm), ApplyTerm), _), List())
+            if a.tpe.toString.startsWith("scala.collection.immutable.") =>
+              context.warn(tree.pos, self,
+                "Set[T]() creates a new instance. Consider Set.empty which does not allocate a new object. " +
+                  tree.toString().take(500))
           case _ => continue(tree)
         }
       }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PreferSetEmptyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PreferSetEmptyTest.scala
@@ -42,4 +42,18 @@ class PreferSetEmptyTest extends FreeSpec with Matchers with PluginRunner with O
       compiler.scapegoat.feedback.warnings.size shouldBe 0
     }
   }
+  "mutable.Set" - {
+    "should not report a warning" in {
+      val code = """
+                 | import scala.collection.mutable
+                 | object Test {
+                 |  val set = mutable.Set[String]()
+                 |  set.add("a")
+                 | }""".stripMargin
+
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+
+    }
+  }
 }


### PR DESCRIPTION
The hint to use `Set.empty` instead of `Set()` is relevant only if immutable sets are used. For mutable sets the suggestion is invalid.
