### PR TITLE
False positive: super different args

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/NoOpOverride.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/NoOpOverride.scala
@@ -10,11 +10,20 @@ class NoOpOverride extends Inspection("No op Override", Levels.Info) {
 
       import context.global._
 
+      private def argumentsMatch(signatureArgs: List[ValDef], actualArgs: List[Tree]) = {
+        signatureArgs.size == actualArgs.size &&
+         signatureArgs.zip(actualArgs).forall {
+          case (sig, act: Ident) => sig.name == act.name
+          case _ => false
+         }
+      }
+
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case DefDef(mods, name, _, vparamss, _, Apply(Select(Super(This(_), _), name2), args)) if name == name2 && vparamss.foldLeft(0)((a, b) => a + b.size) == args.size =>
-            context.warn(tree.pos, self,
-              "This method is overridden yet only calls super: " + tree.toString().take(200))
+          case DefDef(mods, name, _, vparamss, _, Apply(Select(Super(This(_), _), name2), args))
+            if name == name2 && vparamss.size == 1 && argumentsMatch(vparamss.head, args) =>
+              context.warn(tree.pos, self,
+                "This method is overridden yet only calls super: " + tree.toString().take(200))
           case _ => continue(tree)
         }
       }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/NoOpOverrideTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/NoOpOverrideTest.scala
@@ -44,6 +44,22 @@ class NoOpOverrideTest
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+      "when overriding method calls super with different args" in {
+
+        val code =
+          """
+            |class A {
+            |  def method(what: String) = "A " + what
+            |}
+            |class B extends A {
+            |  override def method(what: String) = super.method("something else than " + what)
+            |}
+          """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+
     }
   }
 }


### PR DESCRIPTION
Fixing another false positive - when a method is an override, its only body is to call super, but with different args. The Scapegoat suggestion of the override being unnecessary doesn't make sense.