### PR TITLE
False positive: Traversable.exists(...) is not always simplifiable to .contains()

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
@@ -16,16 +16,22 @@ class ExistsSimplifiableToContains extends Inspection("Exists simplifiable to co
 
       private val Equals = TermName("$eq$eq")
 
-      private def isContainsType(container: Tree, value: Tree): Boolean = {
+      private def doesElementTypeMatch(container: Tree, value: Tree): Boolean = {
         val valueType = value.tpe.underlying.typeSymbol.tpe
         val traversableType = container.tpe.underlying.baseType(typeOf[Traversable[Any]].typeSymbol)
         traversableType.typeArgs.exists(t => valueType <:< t || valueType =:= t)
       }
 
+      private def isContainsTraversable(tree: Tree): Boolean = {
+        // Traversable itself doesn't include a .contains() method
+        isSet(tree) || isSeq(tree) || isList(tree) || isMap(tree)
+      }
+
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Apply(Select(lhs, TermName("exists")), List(Function(_, Apply(Select(_, Equals), List(x))))) if isTraversable(lhs) && isContainsType(lhs, x) =>
-            context.warn(tree.pos, self, "exists(x => x == y) can be replaced with contains(y): " + tree.toString().take(500))
+          case Apply(Select(lhs, TermName("exists")), List(Function(_, Apply(Select(_, Equals), List(x)))))
+            if isContainsTraversable(lhs) && doesElementTypeMatch(lhs, x) =>
+              context.warn(tree.pos, self, "exists(x => x == y) can be replaced with contains(y): " + tree.toString().take(500))
           case _ => continue(tree)
         }
       }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContainsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContainsTest.scala
@@ -8,8 +8,8 @@ class ExistsSimplifiableToContainsTest extends FreeSpec with Matchers with Plugi
 
   override val inspections = Seq(new ExistsSimplifiableToContains)
 
-  "exists with compatible type" - {
-    "should report warning" in {
+  "should report warning" - {
+    "when exists is called with compatible type" in {
       val code =
         """object Test {
           |val exists1 = List(1,2,3).exists(x => x == 2)
@@ -23,8 +23,8 @@ class ExistsSimplifiableToContainsTest extends FreeSpec with Matchers with Plugi
     }
   }
 
-  "exists with incompatible type" - {
-    "should not report warning" in {
+  "should not report warning" - {
+    "when exists is called with incompatible type" in {
       val code =
         """object Test {
           |val exists1 = List("sam").exists(x => x == new RuntimeException)

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContainsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContainsTest.scala
@@ -35,5 +35,18 @@ class ExistsSimplifiableToContainsTest extends FreeSpec with Matchers with Plugi
       compileCodeSnippet(code)
       compiler.scapegoat.feedback.warnings.size shouldBe 0
     }
+    
+    "when exists is called on an Iterable" in {
+     val code =
+     """
+      |object Test {
+      | def method(): Unit = {
+      |   val l: Iterable[String] = List[String]("a", "b", "c")
+      |   print(l.exists(_ == "a"))
+      | }
+      |}""".stripMargin
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
   }
 }


### PR DESCRIPTION
It turns out the method `.contains()` is not defined in Traversable interface. Only (some) subinterfaces do offer this. Thus Scapegoat is not right suggesting to replace `exists()` with `contains()` in some cases.
An example of such situation is `Iterable[T]` which doesn't define `.contains()`.