### PR TITLE
New (sub-)inspection: Masking exceptions

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/exception/SwallowedException.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/exception/SwallowedException.scala
@@ -10,21 +10,37 @@ class SwallowedException extends Inspection("Empty catch block", Levels.Warning)
 
       import context.global._
 
-      private def warn(cd: CaseDef): Unit = {
-        if (cd.body.toString == "()")
-          context.warn(cd.pos, self, "Empty catch block " + cd.toString().take(100))
+      private def containsMaskingThrow(expectedCauseException: Name, trees: Seq[Tree]): Boolean = {
+        trees.exists(tree => {
+          val thisResult = tree match {
+            case Throw(Apply(Select(New(_), _), args))
+              if args.collect { case Ident(i: Name) if i == expectedCauseException => true }.isEmpty =>
+              true
+            case _ => false
+          }
+          thisResult || containsMaskingThrow(expectedCauseException, tree.children)
+        })
       }
 
       private def checkCatches(defs: List[CaseDef]) = defs.foreach {
         case CaseDef(Bind(TermName("ignored") | TermName("ignore"), _), _, _) =>
-        case cdef @ CaseDef(_, _, Literal(Constant(()))) => warn(cdef)
+
+        case cdef @ CaseDef(_, _, Literal(Constant(())))
+          if cdef.body.toString == "()" =>
+            context.warn(cdef.pos, self, "Empty catch block " + cdef.toString().take(100))
+
+        case cdef @ CaseDef(Bind(caughtException, _), _, subtree)
+          if containsMaskingThrow(caughtException, Seq(subtree)) =>
+            context.warn(cdef.pos, self,
+              "Masking exception by not passing the original exception as cause: " + cdef.toString().take(100))
+
         case _ =>
       }
 
       override def inspect(tree: Tree): Unit = {
         tree match {
           case Try(_, catches, _) => checkCatches(catches)
-          case _                             => continue(tree)
+          case _                  => continue(tree)
         }
       }
     }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/SwallowedExceptionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/SwallowedExceptionTest.scala
@@ -53,9 +53,23 @@ class SwallowedExceptionTest
         compileCodeSnippet(code1)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+      "when exception is masked" in {
+        val code1 = """object Test {
+                         try {
+                           println(Integer.valueOf("asdf"))
+                         } catch {
+                           case nfe: NumberFormatException =>
+                             throw new IllegalArgumentException("not a number")
+                         }
+                       }""".stripMargin
+
+        compileCodeSnippet(code1)
+        compiler.scapegoat.feedback.warnings.size shouldBe 1
+      }
     }
+
     "should not report warning" - {
-      "for exceptions all handled" in {
+      "for all exceptions handled" in {
         val code = """object Test {
                         try {
                         } catch {


### PR DESCRIPTION
Amending the `SwallowedException` inspection to check also against masked exceptions (maybe the inspection should be renamed then?), e.g.
```
object Test {
    try {
        println(Integer.valueOf("asdf"))
    } catch {
        case nfe: NumberFormatException =>
            throw new IllegalArgumentException("not a number")
    }
}
```
hides the real cause of the exception thrown. Thus caused-by section doesn't appear in the eventual stack trace