### PR TITLE
Add release drafter.

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,19 @@
+template: |
+  ## What’s Changed
+  $CHANGES
+categories:
+  - title: "🚀 Features"
+    labels:
+      - "feature"
+      - "enhancement"
+      - "new inspection"
+  - title: "🐛 Bug Fixes"
+    labels:
+      - "fix"
+      - "bugfix"
+      - "bug"
+      - "false positive"
+  - title: "🧰 Maintenance"
+    label: "chore"
+  - title: "🔧 Dependency updates"
+    label: "dependency-update"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ credentials.sbt
 .ensime
 .ensime_cache
 target
+
+# metals
+.bloop
+.metals
+metals.sbt


### PR DESCRIPTION
This PR adds [release drafter](https://github.com/marketplace/actions/release-drafter) config and a GitHub action to update the current release draft every time a PR gets merged to master.

I've set up the categories based on existing labels, but I also added
- `Maintenance` (I'd recommend adding a new label `chore` for any maintenance related work), and
- `Dependency updates` - for when scapegoat gets added to Scala Steward.

Closes #273.