### PR TITLE
Add mergify to label dependency updates from Scala Steward.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,7 @@
+pull_request_rules:
+  - name: Label scala-steward's PRs
+    conditions:
+      - author=scala-steward
+    actions:
+      label:
+        add: [dependency-update]


### PR DESCRIPTION
I've added mergify config to automatically label PRs from Scala Steward as `dependency-update`, which aligns with the label I added to release drafter config [here](https://github.com/sksamuel/scapegoat/blob/master/.github/release-drafter.yml#L19).

In order for this to work a maintainer needs to add the `dependency-update` label and enable mergify for this project https://dashboard.mergify.io. We should do the same for sbt-scapegoat.