### PR TITLE
Fixes #298. Disabling coursier

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -156,3 +156,6 @@ packageBin in Compile := crossTarget.value / (assemblyJarName in assembly).value
 
 // debug assembly process
 //logLevel in assembly := Level.Debug
+
+// https://github.com/sksamuel/scapegoat/issues/298
+ThisBuild / useCoursier := false


### PR DESCRIPTION
Disabling coursier as it causes `2.13.0` tests to fail