### PR TITLE
Making ExistsSimplifiableToContains more precise

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
@@ -2,8 +2,6 @@ package com.sksamuel.scapegoat.inspections.collections
 
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
-import scala.collection.mutable
-
 /**
  * @author Stephen Samuel
  *

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContains.scala
@@ -2,6 +2,8 @@ package com.sksamuel.scapegoat.inspections.collections
 
 import com.sksamuel.scapegoat.{Inspection, InspectionContext, Inspector, Levels}
 
+import scala.collection.mutable
+
 /**
  * @author Stephen Samuel
  *
@@ -27,10 +29,23 @@ class ExistsSimplifiableToContains extends Inspection("Exists simplifiable to co
         isSet(tree) || isSeq(tree) || isList(tree) || isMap(tree)
       }
 
+      private def countUsagesOfAVariable(trees: List[Tree], symbolName: String): Int = {
+        trees.map {
+          case Select(Ident(TermName(termName)), _) if termName == symbolName =>
+            1
+          case tree =>
+            countUsagesOfAVariable(tree.children, symbolName)
+        }.sum
+      }
+
       override def inspect(tree: Tree): Unit = {
         tree match {
-          case Apply(Select(lhs, TermName("exists")), List(Function(_, Apply(Select(_, Equals), List(x)))))
-            if isContainsTraversable(lhs) && doesElementTypeMatch(lhs, x) =>
+          case Apply(
+                Select(lhs, TermName("exists")),
+                List(Function(List(ValDef(_, TermName(iterationVariable), _, _)), subtree@Apply(Select(name, Equals), List(x))))
+               )
+            if isContainsTraversable(lhs) && doesElementTypeMatch(lhs, x)
+               && countUsagesOfAVariable(List(subtree), iterationVariable) == 1 =>
               context.warn(tree.pos, self, "exists(x => x == y) can be replaced with contains(y): " + tree.toString().take(500))
           case _ => continue(tree)
         }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContainsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContainsTest.scala
@@ -23,6 +23,21 @@ class ExistsSimplifiableToContainsTest extends AnyFreeSpec with Matchers with Pl
       compileCodeSnippet(code)
       compiler.scapegoat.feedback.warnings.size shouldBe 3
     }
+
+    "when exists is called with a function mapping to something else" in {
+      val code =
+        """
+          |object Test {
+          |  def isItA(strings: String*): Boolean = {
+          |    strings.exists { element =>
+          |      element.toLowerCase == "a"
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 1
+    }
   }
 
   "should not report warning" - {
@@ -47,6 +62,36 @@ class ExistsSimplifiableToContainsTest extends AnyFreeSpec with Matchers with Pl
       |   print(l.exists(_ == "a"))
       | }
       |}""".stripMargin
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+
+    "when exists is called with item comparing to a function of itself" in {
+      val code =
+        """
+          |object Test {
+          |  def atLeastOneIsAllLowercase(strings: String*): Boolean = {
+          |    strings.exists { element =>
+          |      element == element.toLowerCase
+          |    }
+          |  }
+          |}
+          |""".stripMargin
+      compileCodeSnippet(code)
+      compiler.scapegoat.feedback.warnings.size shouldBe 0
+    }
+
+    "when exists is called with a function transforming the elements in two different ways" in {
+      val code =
+        """
+          |object Test {
+          |  def containsNoA(strings: String*): Boolean = {
+          |    strings.exists { element =>
+          |      element.replaceAll("a", "").size == element.size
+          |    }
+          |  }
+          |}
+          |""".stripMargin
       compileCodeSnippet(code)
       compiler.scapegoat.feedback.warnings.size shouldBe 0
     }


### PR DESCRIPTION
Fixing #297 by making the criteria for `ExistsSimplifiableToContains` more precise.
e.g. `exists(string => string.toLowerCase == string)` is not replacable with `contains`