### PR TITLE
Fixing (Collection[Any] warnings of promotion to Collection[Any]) for Seq.empty

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
@@ -22,7 +22,7 @@ class CollectionPromotionToAny
 
       private def isSeq(symbol: Symbol): Boolean = {
         val full = symbol.typeSignature.resultType.typeSymbol.fullName
-        full.startsWith("scala.collection.immutable") &&
+        full.startsWith("scala.collection.") &&
         (full.endsWith("List") || full.endsWith("Set") || full.endsWith("Seq") || full.endsWith("Vector"))
       }
 

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
@@ -22,8 +22,10 @@ class CollectionPromotionToAny
 
       private def isSeq(symbol: Symbol): Boolean = {
         val full = symbol.typeSignature.resultType.typeSymbol.fullName
-        full.startsWith("scala.collection.") &&
-        (full.endsWith("List") || full.endsWith("Set") || full.endsWith("Seq") || full.endsWith("Vector"))
+        val immutableCollection = full.startsWith("scala.collection.immutable") &&
+          (full.endsWith("List") || full.endsWith("Set") || full.endsWith("Seq") || full.endsWith("Vector"))
+
+        immutableCollection || full == "scala.collection.Seq"
       }
 
       private def isAny(tree: Tree): Boolean = tree.toString() == "Any"

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAnyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAnyTest.scala
@@ -14,94 +14,80 @@ class CollectionPromotionToAnyTest
 
   override val inspections = Seq(new CollectionPromotionToAny)
 
-  "lists using colon add with list" - {
-    "should report warning" in {
-      val code = """object Test {
-                   |  val a = List(1, 2, 3)
-                   |  val b = List(4, 5, 6)
-                   |  val c = a :+ b
+  "CollectionPromotionToAny" - {
+    "should report warning" - {
+      "lists using colon add with list" in {
+        val code = """object Test {
+                     |  val a = List(1, 2, 3)
+                     |  val b = List(4, 5, 6)
+                     |  val c = a :+ b
                     } """.stripMargin
 
-      compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 1
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 1
+      }
+      "seqs using colon add with list" in {
+        val code = """object Test {
+                     |  val a = Seq(1, 2, 3)
+                     |  val b = List(4, 5, 6)
+                     |  val c = a :+ b
+                  } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 1
+      }
+      "lists using colon add with seq" in {
+        val code = """object Test {
+                     |  val a = List(1, 2, 3)
+                     |  val b = Seq(4, 5, 6)
+                     |  val c = a :+ b
+                  } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 1
+      }
+      "seqs using colon add with seq" in {
+        val code = """object Test {
+                     |  val a = Seq(1, 2, 3)
+                     |  val b = Seq(4, 5, 6)
+                     |  val c = a :+ b
+                  } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 1
+      }
     }
-  }
+    "should not report warning" - {
+      "Vectors using colon add with non seq" in {
+        val code = """object Test {
+                     |        val a = Vector(1, 2, 3)
+                     |        val b = 6
+                     |        val c = a :+ b
+                  } """.stripMargin
 
-  "seqs using colon add with list" - {
-    "should report warning" in {
-      val code = """object Test {
-                   |  val a = Seq(1, 2, 3)
-                   |  val b = List(4, 5, 6)
-                   |  val c = a :+ b
-                    } """.stripMargin
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+      "lists using colon add with non seq" in {
+        val code = """object Test {
+                     |        val a = List(1, 2, 3)
+                     |        val b = 4
+                     |        val c = a :+ b
+                  } """.stripMargin
 
-      compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 1
-    }
-  }
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+      "list[any] using colon add" in {
+        val code = """object Test {
+                     |        val a = List[Any](1, 2, 3)
+                     |        val b = "string"
+                     |        val c = a :+ b
+                  } """.stripMargin
 
-  "lists using colon add with seq" - {
-    "should report warning" in {
-      val code = """object Test {
-                   |  val a = List(1, 2, 3)
-                   |  val b = Seq(4, 5, 6)
-                   |  val c = a :+ b
-                    } """.stripMargin
-
-      compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 1
-    }
-  }
-
-  "seqs using colon add with seq" - {
-    "should report warning" in {
-      val code = """object Test {
-                   |  val a = Seq(1, 2, 3)
-                   |  val b = Seq(4, 5, 6)
-                   |  val c = a :+ b
-                    } """.stripMargin
-
-      compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 1
-    }
-  }
-
-  "Vectors using colon add with non seq" - {
-    "should not report warning" in {
-      val code = """object Test {
-                   |        val a = Vector(1, 2, 3)
-                   |        val b = 6
-                   |        val c = a :+ b
-                    } """.stripMargin
-
-      compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 0
-    }
-  }
-
-  "lists using colon add with non seq" - {
-    "should not report warning" in {
-      val code = """object Test {
-                   |        val a = List(1, 2, 3)
-                   |        val b = 4
-                   |        val c = a :+ b
-                    } """.stripMargin
-
-      compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 0
-    }
-  }
-
-  "list[any] using colon add" - {
-    "should not report warning" in {
-      val code = """object Test {
-                   |        val a = List[Any](1, 2, 3)
-                   |        val b = "string"
-                   |        val c = a :+ b
-                    } """.stripMargin
-
-      compileCodeSnippet(code)
-      compiler.scapegoat.feedback.warnings.size shouldBe 0
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
     }
   }
 }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAnyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAnyTest.scala
@@ -88,6 +88,15 @@ class CollectionPromotionToAnyTest
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
+      "when adding a string to seq[Any]" in {
+        val code = """object Test {
+                     | val xs = Seq.empty[Any]
+                     | println(xs :+ "hello")
+                     |} """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
     }
   }
 }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAnyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAnyTest.scala
@@ -56,6 +56,15 @@ class CollectionPromotionToAnyTest
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
+      "mutable seqs" in {
+        val code = """object Test {
+                     |  val a = collection.mutable.Buffer[Any]()
+                     |  a += "hello"
+                    } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
     }
     "should not report warning" - {
       "Vectors using colon add with non seq" in {
@@ -88,7 +97,7 @@ class CollectionPromotionToAnyTest
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }
-      "when adding a string to seq[Any]" in {
+      "when adding a string to seq.empty[Any]" in {
         val code = """object Test {
                      | val xs = Seq.empty[Any]
                      | println(xs :+ "hello")


### PR DESCRIPTION
Fixing #315 which turns out to be a special case of `Seq.empty[Any]` which is not handled way. It turns out Seq.empty's full type does not start with `scala.collection.immutable` (at least in 2.12)