### PR TITLE
Only report warnings via the reporter

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -56,17 +56,17 @@ class Feedback(
       inspection = inspection.getClass.getCanonicalName
     )
     warningsBuffer.append(warning)
-    if (shouldPrint(warning)) {
-      println(s"[${warning.level.toString.toLowerCase}] $sourceFileNormalized:${warning.line}: $text")
-      println(s"          $explanation")
-      snippet.foreach(s => println(s"          $s"))
-      println()
-    }
 
-    adjustedLevel match {
-      case Levels.Error   => reporter.error(pos, text)
-      case Levels.Warning => reporter.warning(pos, text)
-      case Levels.Info    => reporter.info(pos, text, force = false)
+    if (shouldPrint(warning)) {
+      val snippetText = snippet.fold("")("\n  " + _ + "\n")
+      val report = s"""|[scapegoat] $text
+                       |  $explanation$snippetText""".stripMargin
+
+      adjustedLevel match {
+        case Levels.Error   => reporter.error(pos, report)
+        case Levels.Warning => reporter.warning(pos, report)
+        case Levels.Info    => reporter.info(pos, report, force = false)
+      }
     }
   }
 

--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -160,7 +160,7 @@ class ScapegoatComponent(val global: Global, inspections: Seq[Inspection])
   var disabledInspections: List[String] = Nil
   var enabledInspections: List[String] = Nil
   var ignoredFiles: List[String] = Nil
-  var consoleOutput: Boolean = false
+  var consoleOutput: Boolean = true
   var verbose: Boolean = false
   val debug: Boolean = false
   var summary: Boolean = true

--- a/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
@@ -32,9 +32,11 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is explanation."
         )
         val reporter = new StoreReporter
-        val feedback = new Feedback(false, reporter, defaultSourcePrefix)
+        val feedback = new Feedback(true, reporter, defaultSourcePrefix)
         feedback.warn(position, inspection)
-        reporter.infos should contain(reporter.Info(position, "My default is Error", reporter.ERROR))
+        reporter.infos should contain(
+          reporter.Info(position, "[scapegoat] My default is Error\n  This is explanation.", reporter.ERROR)
+        )
       }
       "for warning" in {
         val inspection = new DummyInspection(
@@ -44,9 +46,12 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is explanation."
         )
         val reporter = new StoreReporter
-        val feedback = new Feedback(false, reporter, defaultSourcePrefix)
+        val feedback = new Feedback(true, reporter, defaultSourcePrefix)
         feedback.warn(position, inspection)
-        reporter.infos should contain(reporter.Info(position, "My default is Warning", reporter.WARNING))
+        reporter.infos should contain(
+          reporter
+            .Info(position, "[scapegoat] My default is Warning\n  This is explanation.", reporter.WARNING)
+        )
       }
       "for info" in {
         val inspection = new DummyInspection(
@@ -56,9 +61,11 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is explanation."
         )
         val reporter = new StoreReporter
-        val feedback = new Feedback(false, reporter, defaultSourcePrefix)
+        val feedback = new Feedback(true, reporter, defaultSourcePrefix)
         feedback.warn(position, inspection)
-        reporter.infos should contain(reporter.Info(position, "My default is Info", reporter.INFO))
+        reporter.infos should contain(
+          reporter.Info(position, "[scapegoat] My default is Info\n  This is explanation.", reporter.INFO)
+        )
       }
     }
     "should use proper paths" - {
@@ -111,7 +118,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
         )
         val inspections = Seq(inspectionError, inspectionWarning, inspectionInfo)
         val reporter = new StoreReporter
-        val feedback = new Feedback(false, reporter, defaultSourcePrefix, Levels.Info)
+        val feedback = new Feedback(true, reporter, defaultSourcePrefix, Levels.Info)
         inspections.foreach(inspection => feedback.warn(position, inspection))
         feedback.warningsWithMinimalLevel.length should be(3)
       }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElseTest.scala
@@ -1,10 +1,11 @@
 package com.sksamuel.scapegoat.inspections.collections
 
 import com.sksamuel.scapegoat.PluginRunner
+import org.scalatest.OneInstancePerTest
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-class MapGetAndGetOrElseTest extends AnyFreeSpec with Matchers with PluginRunner {
+class MapGetAndGetOrElseTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
 
   override val inspections = Seq(new MapGetAndGetOrElse)
 


### PR DESCRIPTION
Currently, any warning is reported twice (depending on the minimal level and the current level of the warning): once using println, and once properly using the given reporter.

Using `println` is bad for several reasons; the output looks different (ie. the level is not colored, it prints "warnings" instead of "warn"), it cannot be filtered via SBT's LogManager facility (ie. by switching the log level).

This PR simply uses the given reporter to report findings in standard format to the console. It also uses a normal filename instead of the weird "normalized" file name (I really would like to get rid of the `normalizedSourceFile` -- I cannot think of a reason someone would want this...)

Also, output is marked with `[scapegoat]` to inform users that Scapegoat is the origin of the reported problem. (which is similar to wartremover)

Output before:
```
[info] .home.claudio.src.proj.importer.app.importer.models.Event.scala:27: Missing final modifier on case class
          Using case classes without final modifier can lead to surprising breakage.

[info] /home/claudio/src/proj/app/importer/models/Event.scala:27:12: Missing final modifier on case class
[info] case class VenueReference(id: Long)
[info]            ^
```
Output after:
```
[info] /home/claudio/src/proj/app/importer/models/Event.scala:27:12: [scapegoat] Missing final modifier on case class
[info]   Using case classes without final modifier can lead to surprising breakage.
[info] case class VenueReference(id: Long)
[info]            ^
```
(shameless self plug) Using with [sbt-hyperlink](https://github.com/avdv/sbt-hyperlink) you can get clickable links in your terminal which opens your editor at the position of the problem.
