### PR TITLE
Add a release workflow.

### DIFF
--- a/.github/workflows/master-release.yml
+++ b/.github/workflows/master-release.yml
@@ -1,0 +1,43 @@
+name: Release
+on:
+  push:
+    branches: [master]
+    tags: ["*"]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
+      - uses: olafurpg/setup-scala@v7
+        with:
+          java-version: adopt@1.8
+      - run: |
+          sudo apt-get update && sudo apt-get -y install gnupg2
+          mkdir ~/.gnupg && chmod 700 ~/.gnupg
+          echo use-agent >> ~/.gnupg/gpg.conf
+          echo pinentry-mode loopback >> ~/.gnupg/gpg.conf
+          echo allow-loopback-pinentry >> ~/.gnupg/gpg-agent.conf
+          chmod 600 ~/.gnupg/*
+          echo RELOADAGENT | gpg-connect-agent
+          echo $PGP_SECRET | base64 --decode | gpg --import --no-tty --batch --yes
+        env:
+          PGP_SECRET: ${{secrets.PGP_SECRET}}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.ivy2/cache
+          key: ivy-${{hashFiles('**/*.sbt')}}
+          restore-keys: |
+            ivy-
+      - uses: actions/cache@v1
+        with:
+          path: ~/.sbt
+          key: sbt-${{hashFiles('**/*.sbt')}}-${{hashFiles('project/build.properties')}}
+          restore-keys: |
+            sbt-
+      - run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{secrets.PGP_PASSPHRASE}}
+          PGP_SECRET: ${{secrets.PGP_SECRET}}
+          SONATYPE_PASSWORD: ${{secrets.SONATYPE_PASSWORD}}
+          SONATYPE_USERNAME: ${{secrets.SONATYPE_USERNAME}}

--- a/build.sbt
+++ b/build.sbt
@@ -1,26 +1,38 @@
-import com.typesafe.sbt.pgp.PgpKeys
-import sbt.Keys._
-
 // compiler plugins
 addCompilerPlugin(scalafixSemanticdb)
 
 name := "scalac-scapegoat-plugin"
-
 organization := "com.sksamuel.scapegoat"
+description := "Scala compiler plugin for static code analysis"
+homepage := Some(url("https://github.com/sksamuel/scapegoat"))
+licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/sksamuel/scapegoat"),
+    "scm:git@github.com:sksamuel/scapegoat.git",
+    Some("scm:git@github.com:sksamuel/scapegoat.git")
+  )
+)
+developers := List(
+  Developer(
+    "sksamuel",
+    "sksamuel",
+    "@sksamuel",
+    url("https://github.com/sksamuel")
+  )
+)
 
 scalaVersion := "2.13.1"
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.12.11", "2.13.0", "2.13.1")
+autoScalaLibrary := false
 crossVersion := CrossVersion.full
 crossTarget := {
   // workaround for https://github.com/sbt/sbt/issues/5097
   target.value / s"scala-${scalaVersion.value}"
 }
-releaseCrossBuild := true
 
-sbtVersion in Global := "1.1.6"
-
-SbtPgp.autoImport.useGpg := true
-
-SbtPgp.autoImport.useGpgAgent := true
+// https://github.com/sksamuel/scapegoat/issues/298
+ThisBuild / useCoursier := false
 
 val scalac13Options = Seq(
   "-Xlint:adapted-args",
@@ -31,7 +43,6 @@ val scalac13Options = Seq(
   "-Yrangepos",
   "-Ywarn-unused"
 )
-
 val scalac12Options = Seq(
   "-Xlint:adapted-args",
   "-Ywarn-inaccessible",
@@ -41,7 +52,6 @@ val scalac12Options = Seq(
   "-Xmax-classfile-name",
   "254"
 )
-
 val scalac11Options = Seq(
   "-Ywarn-adapted-args",
   "-Ywarn-inaccessible",
@@ -54,7 +64,6 @@ val scalac11Options = Seq(
   "254"
   //"-Ywarn-value-discard"
 )
-
 scalacOptions := {
   val common = Seq(
     "-unchecked",
@@ -64,16 +73,16 @@ scalacOptions := {
     "utf8",
     "-Xlint"
   )
-
   common ++ (scalaBinaryVersion.value match {
     case "2.11" => scalac11Options
     case "2.12" => scalac12Options
     case "2.13" => scalac13Options
   })
 }
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
-fullClasspath in console in Compile ++= (fullClasspath in Test).value // because that's where "PluginRunner" is
-
+// because that's where "PluginRunner" is
+fullClasspath in console in Compile ++= (fullClasspath in Test).value
 initialCommands in console := s"""
 import com.sksamuel.scapegoat._
 def check(code: String) = {
@@ -86,8 +95,6 @@ def check(code: String) = {
   feedback
 }
 """
-
-javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 libraryDependencies ++= Seq(
   "org.scala-lang"         % "scala-reflect"  % scalaVersion.value % "provided",
@@ -107,65 +114,28 @@ libraryDependencies ++= Seq(
   "org.slf4j"      % "slf4j-api"      % "1.7.30"           % "test"
 )
 
-sbtrelease.ReleasePlugin.autoImport.releasePublishArtifactsAction := PgpKeys.publishSigned.value
-
-sbtrelease.ReleasePlugin.autoImport.releaseCrossBuild := true
-
-publishTo := Some(
-  if (isSnapshot.value)
-    Opts.resolver.sonatypeSnapshots
-  else
-    Opts.resolver.sonatypeStaging
-)
-
-publishMavenStyle := true
-
-publishArtifact in Test := false
-
+// Test
+fork in (Test, run) := true
+logBuffered in Test := false
 parallelExecution in Test := false
 
-pomIncludeRepository := { _ => false }
+// ScalaTest reporter config:
+// -o - standard output,
+// D - show all durations,
+// T - show reminder of failed and cancelled tests with short stack traces,
+// F - show full stack traces.
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDTF")
 
-pomExtra := {
-  <url>https://github.com/sksamuel/scapegoat</url>
-    <licenses>
-      <license>
-        <name>Apache 2</name>
-        <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        <distribution>repo</distribution>
-      </license>
-    </licenses>
-    <scm>
-      <url>git@github.com:sksamuel/scapegoat.git</url>
-      <connection>scm:git@github.com:sksamuel/scapegoat.git</connection>
-    </scm>
-    <developers>
-      <developer>
-        <id>sksamuel</id>
-        <name>sksamuel</name>
-        <url>http://github.com/sksamuel</url>
-      </developer>
-    </developers>
-}
-
+// Assembly
 // include the scala xml and compat modules into the final jar, shaded
 assemblyShadeRules in assembly := Seq(
   ShadeRule.rename("scala.xml.**" -> "scapegoat.xml.@1").inAll,
   ShadeRule.rename("scala.collection.compat.**" -> "scapegoat.compat.@1").inAll
 )
-
-// do not run tests during assembly
-test in assembly := {}
-
-autoScalaLibrary := false
-makePom := makePom.dependsOn(assembly).value
 packageBin in Compile := crossTarget.value / (assemblyJarName in assembly).value
-
-// debug assembly process
-//logLevel in assembly := Level.Debug
-
-// https://github.com/sksamuel/scapegoat/issues/298
-ThisBuild / useCoursier := false
+makePom := makePom.dependsOn(assembly).value
+test in assembly := {} // do not run tests during assembly
+publishArtifact in Test := false
 
 // Scalafix
 scalafixDependencies in ThisBuild += "com.nequissimus" %% "sort-imports" % "0.3.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,10 @@
 resolvers += Classpaths.sbtPluginReleases
 
-addSbtPlugin("com.jsuereth"      % "sbt-pgp"       % "1.1.2")
-addSbtPlugin("com.github.gseitz" % "sbt-release"   % "1.0.13")
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"  % "0.14.10")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"  % "2.3.2")
-addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"  % "0.9.12")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("com.geirsson"  % "sbt-ci-release" % "1.5.2")
+addSbtPlugin("com.eed3si9n"  % "sbt-assembly"   % "0.14.10")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt"   % "2.3.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"   % "0.9.12")
+addSbtPlugin("org.scoverage" % "sbt-scoverage"  % "1.6.1")
 
 if (System.getProperty("add-scapegoat-plugin") == "true")
   addSbtPlugin(s"com.sksamuel.scapegoat" % "sbt-scapegoat" % "1.1.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "1.4.3-SNAPSHOT"


### PR DESCRIPTION
This PR adds a release workflow using sbt-ci-release.

Here is how it works:
1. This workflow gets run every time a PR is merged to master and publishes a snapshot release for each version defined in the build.sbt file (we agreed we would release for the latest version of 2.11 and the two recent releases of 2.12 and 2.13). The snapshot is in the following format, e.g. `1.4.2+11-01b5562a+20200328-1650-SNAPSHOT` - it comprises of the most recent tag + distance of the HEAD commit from the tag (11 in this case), SHA of the HEAD (01b5562a), the current timestamp and the suffix `-SNAPSHOT`.
2. This workflow also runs each time a new tag is pushed to the repo and publishes a new release using the tag as the new version. sbt-ci-release identifies automatically that it needs to release a regular version instead of a snapshot using the sbt-dynver plugin, which happens under the hood. sbt-ci-release also takes care of signing (using sbt-pgp) and obviously publishing to sonatype (via sbt-sonatype).

You can read more about how it works in the project repo https://github.com/olafurpg/sbt-ci-release.

Required set-up:
@sksamuel, I'm going to need you to do a set of steps on your end to make this work (you can follow the instruction in the sbt-ci-release repo, but here's a summary of what's required).
1. You need to create a new GPG key used for signing scapegoat, submit it to the Ubuntu's OpenPGP keyserver and the `PGP_PASSPHRASE` and `PGP_SECRET` env variables as github secrets (in the repo settings). The `PGP_SECRET` needs to be base64 encoded.
1. Add `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` as secrets. Those are the credentials used to publish to oss.sonatype.org. If you don't want to use your personal credentials, you can get a new bot account created and added (with publishing rights) to the `com.sksamuel.scapegoat` org.

Let me know once all that is done so we can merge this PR and test publishing snapshots from master before we try to publish a new release. 

Notes:
- when you push a new tag it needs to include a version starting with a `v`, e.g. `v1.5.0` - I can see you've been following this rule anyway so that shouldn't be a problem.

Relates to #306. 