### PR TITLE
False-positive - empty methods no so empty

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyMethod.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/empty/EmptyMethod.scala
@@ -22,7 +22,7 @@ class EmptyMethod
           case DefDef(mods, _, _, _, _, _) if mods.isOverride                                   =>
           case ClassDef(mods, _, _, _) if mods.isTrait                                          => continue(tree)
           case DefDef(_, _, _, _, _, _) if tree.symbol != null && tree.symbol.enclClass.isTrait =>
-          case DefDef(_, _, _, _, _, Literal(Constant(()))) =>
+          case d @ DefDef(_, _, _, _, _, Literal(Constant(()))) if d.symbol != null && d.symbol.isPrivate =>
             context.warn(tree.pos, self, tree.toString.take(500))
           case _ => continue(tree)
         }

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyMethodTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyMethodTest.scala
@@ -13,12 +13,12 @@ class EmptyMethodTest extends AnyFreeSpec with Matchers with PluginRunner with O
   "empty method" - {
     "should report warning" in {
       val code = """object Test {
-                      def foo = { }
-                      def foo2 = true
-                      def foo3 = {
+                      private def foo = { }
+                      private def foo2 = true
+                      private def foo3 = {
                         ()
                       }
-                      def foo4 = {
+                      private def foo4 = {
                         println("sammy")
                         ()
                       }
@@ -30,6 +30,26 @@ class EmptyMethodTest extends AnyFreeSpec with Matchers with PluginRunner with O
     "should not report warning" - {
       "for empty trait methods" in {
         val code = """trait A { def foo = () } """
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+
+      "for empty methods in public classes" in {
+        val code =
+          """
+            |class Animal {
+            |  def makeSound(): Unit = {}
+            |}
+            |
+            |class Dog extends Animal {
+            |  override def makeSound(): Unit = {
+            |    println("Bark")
+            |  }
+            |}
+            |
+            |class Fish extends Animal {}
+            |""".stripMargin
+
         compileCodeSnippet(code)
         compiler.scapegoat.feedback.warnings.size shouldBe 0
       }


### PR DESCRIPTION
To define empty methods is a valid technique especially in interfaces (internal interfaces within the program, or APIs). I agree an empty private method should be avoided.