### PR TITLE
Adding InspectionTest as a superclass for all inspection tests

### DIFF
--- a/src/test/scala/com/sksamuel/scapegoat/InspectionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/InspectionTest.scala
@@ -1,0 +1,7 @@
+package com.sksamuel.scapegoat
+
+import org.scalatest.OneInstancePerTest
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+abstract class InspectionTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {}

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/AnyUseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/AnyUseTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class AnyUseTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class AnyUseTest extends InspectionTest {
 
   override val inspections = Seq(new AnyUse)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/AsInstanceOfTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/AsInstanceOfTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.unsafe.AsInstanceOf
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
-class AsInstanceOfTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class AsInstanceOfTest extends InspectionTest {
 
   override val inspections = Seq(new AsInstanceOf)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/AvoidToMinusOneTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/AvoidToMinusOneTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class AvoidToMinusOneTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class AvoidToMinusOneTest extends InspectionTest {
 
   override val inspections = Seq(new AvoidToMinusOne)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/ChainedPackageClauseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/ChainedPackageClauseTest.scala
@@ -1,8 +1,0 @@
-package com.sksamuel.scapegoat.inspections
-
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-/** @author Stephen Samuel */
-class ChainedPackageClauseTest extends AnyFreeSpec with Matchers with OneInstancePerTest {}

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/ConstantIfTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/ConstantIfTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.unneccesary.ConstantIf
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class ConstantIfTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class ConstantIfTest extends InspectionTest {
 
   override val inspections = Seq(new ConstantIf)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/DoubleNegationTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/DoubleNegationTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class DoubleNegationTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class DoubleNegationTest extends InspectionTest {
 
   override val inspections = Seq(new DoubleNegation)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/EitherGetTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/EitherGetTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.option.EitherGet
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
-class EitherGetTest extends AnyFreeSpec with Matchers with PluginRunner {
+class EitherGetTest extends InspectionTest {
 
   override val inspections = Seq(new EitherGet)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/FinalModifierOnCaseClassTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/FinalModifierOnCaseClassTest.scala
@@ -1,15 +1,7 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class FinalModifierOnCaseClassTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class FinalModifierOnCaseClassTest extends InspectionTest {
 
   override val inspections = Seq(new FinalModifierOnCaseClass)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/FinalizerWithoutSuperTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/FinalizerWithoutSuperTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.unsafe.FinalizerWithoutSuper
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class FinalizerWithoutSuperTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class FinalizerWithoutSuperTest extends InspectionTest {
 
   override val inspections = Seq(new FinalizerWithoutSuper)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/IsInstanceOfTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/IsInstanceOfTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.unsafe.IsInstanceOf
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class IsInstanceOfTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class IsInstanceOfTest extends InspectionTest {
 
   override val inspections = Seq(new IsInstanceOf)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/LonelySealedTraitTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/LonelySealedTraitTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class LonelySealedTraitTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class LonelySealedTraitTest extends InspectionTest {
 
   override val inspections = Seq(new LonelySealedTrait)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/MaxParameterTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/MaxParameterTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class MaxParameterTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class MaxParameterTest extends InspectionTest {
 
   override val inspections = Seq(new MaxParameters)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/MethodReturningAnyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/MethodReturningAnyTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.inference.MethodReturningAny
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class MethodReturningAnyTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class MethodReturningAnyTest extends InspectionTest {
 
   override val inspections = Seq(new MethodReturningAny)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/PublicFinalizerTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/PublicFinalizerTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class PublicFinalizerTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class PublicFinalizerTest extends InspectionTest {
 
   override val inspections = Seq(new PublicFinalizer)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/RedundantFinalModifierOnMethodTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/RedundantFinalModifierOnMethodTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class RedundantFinalModifierOnMethodTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class RedundantFinalModifierOnMethodTest extends InspectionTest {
 
   override val inspections = Seq(new RedundantFinalModifierOnMethod)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/RedundantFinalModifierOnVarTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/RedundantFinalModifierOnVarTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class RedundantFinalModifierOnVarTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class RedundantFinalModifierOnVarTest extends InspectionTest {
 
   override val inspections = Seq(new RedundantFinalModifierOnVar)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/TryGetTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/TryGetTest.scala
@@ -1,12 +1,10 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.unsafe.TryGet
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class TryGetTest extends AnyFreeSpec with PluginRunner with Matchers {
+class TryGetTest extends InspectionTest {
 
   override val inspections = Seq(new TryGet)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/TypeShadowingTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/TypeShadowingTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class TypeShadowingTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class TypeShadowingTest extends InspectionTest {
 
   override val inspections = Seq(new TypeShadowing)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/VarClosureTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/VarClosureTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class VarClosureTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class VarClosureTest extends InspectionTest {
 
   override val inspections = Seq(new VarClosure)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/VarCouldBeValTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/VarCouldBeValTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.unneccesary.VarCouldBeVal
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
-class VarCouldBeValTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class VarCouldBeValTest extends InspectionTest {
 
   override val inspections = Seq(new VarCouldBeVal)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/VarUseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/VarUseTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class VarUseTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class VarUseTest extends InspectionTest {
 
   override val inspections = Seq(new VarUse)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/VariableShadowingTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/VariableShadowingTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class VariableShadowingTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class VariableShadowingTest extends InspectionTest {
 
   override val inspections = Seq(new VariableShadowing)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/WhileTrueTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/WhileTrueTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.controlflow.WhileTrue
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class WhileTrueTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class WhileTrueTest extends InspectionTest {
 
   override val inspections = Seq(new WhileTrue)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ArrayEqualsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ArrayEqualsTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ArrayEqualsTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class ArrayEqualsTest extends InspectionTest {
 
   override val inspections = Seq(new ArrayEquals)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/AvoidSizeEqualsZeroTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/AvoidSizeEqualsZeroTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class AvoidSizeEqualsZeroTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class AvoidSizeEqualsZeroTest extends InspectionTest {
 
   override val inspections = Seq(new AvoidSizeEqualsZero)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/AvoidSizeNotEqualsZeroTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/AvoidSizeNotEqualsZeroTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class AvoidSizeNotEqualsZeroTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class AvoidSizeNotEqualsZeroTest extends InspectionTest {
 
   override val inspections = Seq(new AvoidSizeNotEqualsZero)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionIndexOnNonIndexedSeqTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionIndexOnNonIndexedSeqTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Josh Rosen */
-class CollectionIndexOnNonIndexedSeqTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class CollectionIndexOnNonIndexedSeqTest extends InspectionTest {
 
   override val inspections = Seq(new CollectionIndexOnNonIndexedSeq)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNamingConfusionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNamingConfusionTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class CollectionNamingConfusionTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class CollectionNamingConfusionTest extends InspectionTest {
 
   override val inspections = Seq(new CollectionNamingConfusion)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNegativeIndexTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionNegativeIndexTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class CollectionNegativeIndexTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class CollectionNegativeIndexTest extends InspectionTest {
 
   override val inspections = Seq(new CollectionNegativeIndex)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAnyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAnyTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class CollectionPromotionToAnyTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class CollectionPromotionToAnyTest extends InspectionTest {
 
   override val inspections = Seq(new CollectionPromotionToAny)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptyListTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptyListTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ComparisonToEmptyListTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class ComparisonToEmptyListTest extends InspectionTest {
 
   override val inspections = Seq(new ComparisonToEmptyList)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptySetTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptySetTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ComparisonToEmptySetTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class ComparisonToEmptySetTest extends InspectionTest {
 
   override val inspections = Seq(new ComparisonToEmptySet)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/DuplicateMapKeyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/DuplicateMapKeyTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class DuplicateMapKeyTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class DuplicateMapKeyTest extends InspectionTest {
 
   override val inspections = Seq(new DuplicateMapKey)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/DuplicateSetValueTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/DuplicateSetValueTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class DuplicateSetValueTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class DuplicateSetValueTest extends InspectionTest {
 
   override val inspections = Seq(new DuplicateSetValue)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContainsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ExistsSimplifiableToContainsTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ExistsSimplifiableToContainsTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class ExistsSimplifiableToContainsTest extends InspectionTest {
 
   override val inspections = Seq(new ExistsSimplifiableToContains)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotHeadOptionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotHeadOptionTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class FilterDotHeadOptionTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class FilterDotHeadOptionTest extends InspectionTest {
 
   override val inspections = Seq(new FilterDotHeadOption)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotHeadTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotHeadTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class FilterDotHeadTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class FilterDotHeadTest extends InspectionTest {
 
   override val inspections = Seq(new FilterDotHead)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotIsEmptyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotIsEmptyTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class FilterDotIsEmptyTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class FilterDotIsEmptyTest extends InspectionTest {
 
   override val inspections = Seq(new FilterDotIsEmpty)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotSizeTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FilterDotSizeTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class FilterDotSizeTest extends AnyFreeSpec with Matchers with PluginRunner {
+class FilterDotSizeTest extends InspectionTest {
 
   override val inspections = Seq(new FilterDotSize)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FilterOptionAndGetTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FilterOptionAndGetTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class FilterOptionAndGetTest extends AnyFreeSpec with Matchers with PluginRunner {
+class FilterOptionAndGetTest extends InspectionTest {
 
   override val inspections = Seq(new FilterOptionAndGet)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FindAndNotEqualsNoneReplaceWithExistsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FindAndNotEqualsNoneReplaceWithExistsTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class FindAndNotEqualsNoneReplaceWithExistsTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class FindAndNotEqualsNoneReplaceWithExistsTest extends InspectionTest {
 
   override val inspections = Seq(new FindAndNotEqualsNoneReplaceWithExists)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FindDotIsDefinedTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/FindDotIsDefinedTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class FindDotIsDefinedTest extends AnyFreeSpec with Matchers with PluginRunner {
+class FindDotIsDefinedTest extends InspectionTest {
 
   override val inspections = Seq(new FindDotIsDefined)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/JavaConversionsUseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/JavaConversionsUseTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.{isScala213, PluginRunner}
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.{isScala213, InspectionTest}
 
 /** @author Stephen Samuel */
-class JavaConversionsUseTest extends AnyFreeSpec with Matchers with PluginRunner {
+class JavaConversionsUseTest extends InspectionTest {
 
   override val inspections = Seq(new JavaConversionsUse)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ListAppendTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ListAppendTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ListAppendTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class ListAppendTest extends InspectionTest {
 
   override val inspections = Seq(new ListAppend)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ListSizeTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ListSizeTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ListSizeTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class ListSizeTest extends InspectionTest {
 
   override val inspections = Seq(new ListSize)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/MapGetAndGetOrElseTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class MapGetAndGetOrElseTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class MapGetAndGetOrElseTest extends InspectionTest {
 
   override val inspections = Seq(new MapGetAndGetOrElse)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/NegationIsEmptyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/NegationIsEmptyTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class NegationIsEmptyTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class NegationIsEmptyTest extends InspectionTest {
 
   override val inspections = Seq(new NegationIsEmpty)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/NegationNonEmptyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/NegationNonEmptyTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class NegationNonEmptyTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class NegationNonEmptyTest extends InspectionTest {
 
   override val inspections = Seq(new NegationNonEmpty)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/NegativeSeqPadTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/NegativeSeqPadTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class NegativeSeqPadTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class NegativeSeqPadTest extends InspectionTest {
 
   override val inspections = Seq(new NegativeSeqPad)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutableTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefIterableIsMutableTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class PredefIterableIsMutableTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class PredefIterableIsMutableTest extends InspectionTest {
 
   override val inspections = Seq(new PredefIterableIsMutable)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefSeqIsMutableTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefSeqIsMutableTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.{isScala213, PluginRunner}
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.{isScala213, InspectionTest}
 
 /** @author Stephen Samuel */
-class PredefSeqIsMutableTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class PredefSeqIsMutableTest extends InspectionTest {
 
   override val inspections = Seq(new PredefSeqIsMutable)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefTraversableIsMutableTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PredefTraversableIsMutableTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.{isScala213, PluginRunner}
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.{isScala213, InspectionTest}
 
 /** @author Stephen Samuel */
-class PredefTraversableIsMutableTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class PredefTraversableIsMutableTest extends InspectionTest {
 
   override val inspections = Seq(new PredefTraversableIsMutable)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PreferMapEmptyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PreferMapEmptyTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class PreferMapEmptyTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class PreferMapEmptyTest extends InspectionTest {
 
   override val inspections = Seq(new PreferMapEmpty)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PreferSeqEmptyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PreferSeqEmptyTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class PreferSeqEmptyTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class PreferSeqEmptyTest extends InspectionTest {
 
   override val inspections = Seq(new PreferSeqEmpty)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PreferSetEmptyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/PreferSetEmptyTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class PreferSetEmptyTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class PreferSetEmptyTest extends InspectionTest {
 
   override val inspections = Seq(new PreferSetEmpty)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ReverseFuncTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ReverseFuncTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class ReverseFuncTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class ReverseFuncTest extends InspectionTest {
 
   override val inspections = Seq(new ReverseFunc)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTailReverseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTailReverseTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class ReverseTailReverseTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class ReverseTailReverseTest extends InspectionTest {
 
   override val inspections = Seq(new ReverseTailReverse)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTakeReverseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ReverseTakeReverseTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class ReverseTakeReverseTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class ReverseTakeReverseTest extends InspectionTest {
 
   override val inspections = Seq(new ReverseTakeReverse)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/SwapSortFilterTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/SwapSortFilterTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class SwapSortFilterTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class SwapSortFilterTest extends InspectionTest {
 
   override val inspections = Seq(new SwapSortFilter)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeContainsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeContainsTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class UnsafeContainsTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class UnsafeContainsTest extends InspectionTest {
 
   override val inspections = Seq(new UnsafeContains)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeTraversableMethodsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/UnsafeTraversableMethodsTest.scala
@@ -1,15 +1,7 @@
 package com.sksamuel.scapegoat.inspections.collections
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class UnsafeTraversableMethodsTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class UnsafeTraversableMethodsTest extends InspectionTest {
 
   override val inspections = Seq(new UnsafeTraversableMethods)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/controlflow/RepeatedIfElseBodyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/controlflow/RepeatedIfElseBodyTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections.controlflow
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class RepeatedIfElseBodyTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class RepeatedIfElseBodyTest extends InspectionTest {
 
   override val inspections = Seq(new RepeatedIfElseBody)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyCaseClassTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyCaseClassTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections.empty
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.EmptyCaseClass
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class EmptyCaseClassTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class EmptyCaseClassTest extends InspectionTest {
 
   override val inspections = Seq(new EmptyCaseClass)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyForTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyForTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.empty
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class EmptyForTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class EmptyForTest extends InspectionTest {
 
   override val inspections = Seq(new EmptyFor)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyIfBlockTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyIfBlockTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.empty
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class EmptyIfBlockTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class EmptyIfBlockTest extends InspectionTest {
 
   override val inspections = Seq(new EmptyIfBlock)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyMethodTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyMethodTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.empty
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class EmptyMethodTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class EmptyMethodTest extends InspectionTest {
 
   override val inspections = Seq(new EmptyMethod)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptySynchronizedBlockTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptySynchronizedBlockTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.empty
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class EmptySynchronizedBlockTest extends AnyFreeSpec with Matchers with PluginRunner {
+class EmptySynchronizedBlockTest extends InspectionTest {
 
   override val inspections = Seq(new EmptySynchronizedBlock)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyTryBlockTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyTryBlockTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.empty
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class EmptyTryBlockTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class EmptyTryBlockTest extends InspectionTest {
 
   override val inspections = Seq(new EmptyTryBlock)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyWhileBlockTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/empty/EmptyWhileBlockTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.empty
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class EmptyWhileBlockTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class EmptyWhileBlockTest extends InspectionTest {
 
   override val inspections = Seq(new EmptyWhileBlock)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/empty/RedundantFinalizerTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/empty/RedundantFinalizerTest.scala
@@ -1,12 +1,10 @@
 package com.sksamuel.scapegoat.inspections.empty
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.unneccesary.RedundantFinalizer
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class RedundantFinalizerTest extends AnyFreeSpec with Matchers with PluginRunner {
+class RedundantFinalizerTest extends InspectionTest {
 
   override val inspections = Seq(new RedundantFinalizer)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingFloatingPointTypesTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingFloatingPointTypesTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.equality
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ComparingFloatingPointTypesTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class ComparingFloatingPointTypesTest extends InspectionTest {
 
   override val inspections = Seq(new ComparingFloatingPointTypes)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypesTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparingUnrelatedTypesTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.equality
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ComparingUnrelatedTypesTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class ComparingUnrelatedTypesTest extends InspectionTest {
 
   override val inspections = Seq(new ComparingUnrelatedTypes)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparisonWithSelfInspectionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/equality/ComparisonWithSelfInspectionTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.equality
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ComparisonWithSelfInspectionTest extends AnyFreeSpec with Matchers with PluginRunner {
+class ComparisonWithSelfInspectionTest extends InspectionTest {
 
   override val inspections = Seq(new ComparisonWithSelf)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchExceptionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchExceptionTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.exception
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Marconi Lanna */
-class CatchExceptionTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class CatchExceptionTest extends InspectionTest {
 
   override val inspections = Seq(new CatchException)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchFatalTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchFatalTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.exception
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Marconi Lanna */
-class CatchFatalTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class CatchFatalTest extends InspectionTest {
 
   override val inspections = Seq(new CatchFatal)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchNpeTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchNpeTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.exception
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class CatchNpeTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class CatchNpeTest extends InspectionTest {
 
   override val inspections = Seq(new CatchNpe)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchThrowableTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/CatchThrowableTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.exception
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class CatchThrowableTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class CatchThrowableTest extends InspectionTest {
 
   override val inspections = Seq(new CatchThrowable)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/IncorrectlyNamedExceptionsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/IncorrectlyNamedExceptionsTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.exception
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class IncorrectlyNamedExceptionsTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class IncorrectlyNamedExceptionsTest extends InspectionTest {
 
   override val inspections = Seq(new IncorrectlyNamedExceptions)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/SwallowedExceptionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/SwallowedExceptionTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.exception
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class SwallowedExceptionTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class SwallowedExceptionTest extends InspectionTest {
 
   override val inspections = Seq(new SwallowedException)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/exception/UnreachableCatchTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/exception/UnreachableCatchTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.exception
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class UnreachableCatchTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class UnreachableCatchTest extends InspectionTest {
 
   override val inspections = Seq(new UnreachableCatch)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/imports/DuplicateImportTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/imports/DuplicateImportTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.imports
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class DuplicateImportTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class DuplicateImportTest extends InspectionTest {
 
   override val inspections = Seq(new DuplicateImport)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/imports/WildcardImportTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/imports/WildcardImportTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.imports
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class WildcardImportTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class WildcardImportTest extends InspectionTest {
 
   override val inspections = Seq(new WildcardImport)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/inferrence/BoundedByFinalTypeTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/inferrence/BoundedByFinalTypeTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections.inferrence
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.inference.BoundedByFinalType
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class BoundedByFinalTypeTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class BoundedByFinalTypeTest extends InspectionTest {
 
   override val inspections = Seq(new BoundedByFinalType)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/inferrence/PointlessTypeBoundsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/inferrence/PointlessTypeBoundsTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections.inferrence
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.inference.PointlessTypeBounds
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class PointlessTypeBoundsTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class PointlessTypeBoundsTest extends InspectionTest {
 
   override val inspections = Seq(new PointlessTypeBounds)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/inferrence/ProductWithSerializableInferredTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/inferrence/ProductWithSerializableInferredTest.scala
@@ -1,12 +1,10 @@
 package com.sksamuel.scapegoat.inspections.inferrence
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.inference.ProductWithSerializableInferred
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class ProductWithSerializableInferredTest extends AnyFreeSpec with Matchers with PluginRunner {
+class ProductWithSerializableInferredTest extends InspectionTest {
 
   override val inspections = Seq(new ProductWithSerializableInferred)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatchTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/matching/PartialFunctionInsteadOfMatchTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.matching
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class PartialFunctionInsteadOfMatchTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class PartialFunctionInsteadOfMatchTest extends InspectionTest {
 
   override val inspections = Seq(new PartialFunctionInsteadOfMatch)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/matching/RepeatedCaseBodyTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/matching/RepeatedCaseBodyTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.matching
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class RepeatedCaseBodyTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class RepeatedCaseBodyTest extends InspectionTest {
 
   override val inspections = Seq(new RepeatedCaseBody)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/matching/SuspiciousMatchOnClassObjectTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/matching/SuspiciousMatchOnClassObjectTest.scala
@@ -1,15 +1,7 @@
 package com.sksamuel.scapegoat.inspections.matching
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class SuspiciousMatchOnClassObjectTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class SuspiciousMatchOnClassObjectTest extends InspectionTest {
 
   override val inspections = Seq(new SuspiciousMatchOnClassObject)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/math/BigDecimalDoubleConstructorTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/math/BigDecimalDoubleConstructorTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.math
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class BigDecimalDoubleConstructorTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class BigDecimalDoubleConstructorTest extends InspectionTest {
 
   override val inspections = Seq(new BigDecimalDoubleConstructor)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/math/BigDecimalScaleWithoutRoundingModeTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/math/BigDecimalScaleWithoutRoundingModeTest.scala
@@ -1,15 +1,7 @@
 package com.sksamuel.scapegoat.inspections.math
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class BigDecimalScaleWithoutRoundingModeTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class BigDecimalScaleWithoutRoundingModeTest extends InspectionTest {
 
   override val inspections = Seq(new BigDecimalScaleWithoutRoundingMode)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/math/BrokenOddnessTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/math/BrokenOddnessTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.math
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class BrokenOddnessTest extends AnyFreeSpec with Matchers with PluginRunner {
+class BrokenOddnessTest extends InspectionTest {
 
   override val inspections = Seq(new BrokenOddness)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/math/DivideByOneTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/math/DivideByOneTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections.math
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class DivideByOneTest extends AnyFreeSpec with PluginRunner with Matchers with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class DivideByOneTest extends InspectionTest {
 
   override val inspections = Seq(new DivideByOne)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/math/ModOneTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/math/ModOneTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.math
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ModOneTest extends AnyFreeSpec with PluginRunner with Matchers {
+class ModOneTest extends InspectionTest {
 
   override val inspections = Seq(new ModOne)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/math/NanComparisonTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/math/NanComparisonTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections.math
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class NanComparisonTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class NanComparisonTest extends InspectionTest {
 
   override val inspections = Seq(new NanComparison)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/math/UseCbrtTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/math/UseCbrtTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.math
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Matic Potočnik */
-class UseCbrtTest extends AnyFreeSpec with Matchers with PluginRunner {
+class UseCbrtTest extends InspectionTest {
 
   override val inspections = Seq(new UseCbrt)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/math/UseLog1PTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/math/UseLog1PTest.scala
@@ -1,10 +1,7 @@
 package com.sksamuel.scapegoat.inspections.math
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class UseLog1PTest extends AnyFreeSpec with Matchers with PluginRunner {
+import com.sksamuel.scapegoat.InspectionTest
+class UseLog1PTest extends InspectionTest {
 
   override val inspections = Seq(new UseLog1P)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/math/UseSqrtTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/math/UseSqrtTest.scala
@@ -1,10 +1,7 @@
 package com.sksamuel.scapegoat.inspections.math
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class UseSqrtTest extends AnyFreeSpec with Matchers with PluginRunner {
+import com.sksamuel.scapegoat.InspectionTest
+class UseSqrtTest extends InspectionTest {
 
   override val inspections = Seq(new UseSqrt)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/math/ZeroNumeratorTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/math/ZeroNumeratorTest.scala
@@ -1,11 +1,7 @@
 package com.sksamuel.scapegoat.inspections.math
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class ZeroNumeratorTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class ZeroNumeratorTest extends InspectionTest {
 
   override val inspections = Seq(new ZeroNumerator)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/names/ClassNamesTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/names/ClassNamesTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections.names
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.naming.ClassNames
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class ClassNamesTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class ClassNamesTest extends InspectionTest {
 
   override val inspections = Seq(new ClassNames)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/names/MethodNamesTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/names/MethodNamesTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections.names
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.naming.MethodNames
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class MethodNamesTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class MethodNamesTest extends InspectionTest {
 
   override val inspections = Seq(new MethodNames)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/names/ObjectNamesTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/names/ObjectNamesTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections.names
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.naming.ObjectNames
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class ObjectNamesTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class ObjectNamesTest extends InspectionTest {
 
   override val inspections = Seq(new ObjectNames)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/nulls/NullAssignmentTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/nulls/NullAssignmentTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.nulls
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class NullAssignmentTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class NullAssignmentTest extends InspectionTest {
 
   override val inspections = Seq(new NullAssignment)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/nulls/NullParameterTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/nulls/NullParameterTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.nulls
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class NullParameterTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class NullParameterTest extends InspectionTest {
 
   override val inspections = Seq(new NullParameter)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/option/ImpossibleOptionSizeConditionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/option/ImpossibleOptionSizeConditionTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.option
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ImpossibleOptionSizeConditionTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class ImpossibleOptionSizeConditionTest extends InspectionTest {
 
   override val inspections = Seq(new ImpossibleOptionSizeCondition)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/option/OptionGetTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/option/OptionGetTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.option
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class OptionGetTest extends AnyFreeSpec with Matchers with PluginRunner {
+class OptionGetTest extends InspectionTest {
 
   override val inspections = Seq(new OptionGet)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/option/OptionSizeTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/option/OptionSizeTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.option
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class OptionSizeTest extends AnyFreeSpec with Matchers with PluginRunner {
+class OptionSizeTest extends InspectionTest {
 
   override val inspections = Seq(new OptionSize)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/ArraysInFormatTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/ArraysInFormatTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ArraysInFormatTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class ArraysInFormatTest extends InspectionTest {
 
   override val inspections = Seq(new ArraysInFormat)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/ArraysToStringTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/ArraysToStringTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ArraysToStringTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class ArraysToStringTest extends InspectionTest {
 
   override val inspections = Seq(new ArraysToString)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/EmptyInterpolatedStringTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/EmptyInterpolatedStringTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.{isScala213, PluginRunner}
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.{isScala213, InspectionTest}
 
 /** @author Stephen Samuel */
-class EmptyInterpolatedStringTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class EmptyInterpolatedStringTest extends InspectionTest {
 
   override val inspections = Seq(new EmptyInterpolatedString)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/IllegalFormatStringTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/IllegalFormatStringTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class IllegalFormatStringTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class IllegalFormatStringTest extends InspectionTest {
 
   override val inspections = Seq(new IllegalFormatString)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormatTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/IncorrectNumberOfArgsToFormatTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class IncorrectNumberOfArgsToFormatTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class IncorrectNumberOfArgsToFormatTest extends InspectionTest {
 
   override val inspections = Seq(new IncorrectNumberOfArgsToFormat)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/InvalidRegexTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/InvalidRegexTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class InvalidRegexTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class InvalidRegexTest extends InspectionTest {
 
   override val inspections = Seq(new InvalidRegex)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/LooksLikeInterpolatedStringTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/LooksLikeInterpolatedStringTest.scala
@@ -1,15 +1,7 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
-
-class LooksLikeInterpolatedStringTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+import com.sksamuel.scapegoat.InspectionTest
+class LooksLikeInterpolatedStringTest extends InspectionTest {
 
   override val inspections = Seq(new LooksLikeInterpolatedString)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/StripMarginOnRegexTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/StripMarginOnRegexTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class StripMarginOnRegexTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class StripMarginOnRegexTest extends InspectionTest {
 
   override val inspections = Seq(new StripMarginOnRegex)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/SubstringZeroTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/SubstringZeroTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class SubstringZeroTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class SubstringZeroTest extends InspectionTest {
 
   override val inspections = Seq(new SubstringZero)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/string/UnsafeStringContainsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/string/UnsafeStringContainsTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.string
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Zack Grannan */
-class UnsafeStringContainsTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class UnsafeStringContainsTest extends InspectionTest {
   override val inspections = Seq(new UnsafeStringContains)
   "unsafe string contains" - {
     "should report warning" in {

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/style/AvoidOperatorOverloadTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/style/AvoidOperatorOverloadTest.scala
@@ -1,12 +1,9 @@
 package com.sksamuel.scapegoat.inspections.style
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class AvoidOperatorOverloadTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class AvoidOperatorOverloadTest extends InspectionTest {
 
   override val inspections = Seq(new AvoidOperatorOverload)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/style/ParameterlessMethodReturnsUnitTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/style/ParameterlessMethodReturnsUnitTest.scala
@@ -1,16 +1,9 @@
 package com.sksamuel.scapegoat.inspections.style
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class ParameterlessMethodReturnsUnitTest
-    extends AnyFreeSpec
-    with Matchers
-    with PluginRunner
-    with OneInstancePerTest {
+class ParameterlessMethodReturnsUnitTest extends InspectionTest {
 
   override val inspections = Seq(new ParameterlessMethodReturnsUnit)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/style/SimplifyBooleanExpressionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/style/SimplifyBooleanExpressionTest.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.scapegoat.inspections.style
 
-import com.sksamuel.scapegoat.PluginRunner
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.InspectionTest
 
 /** @author Stephen Samuel */
-class SimplifyBooleanExpressionTest extends AnyFreeSpec with Matchers with PluginRunner {
+class SimplifyBooleanExpressionTest extends InspectionTest {
 
   override val inspections = Seq(new SimplifyBooleanExpression)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/NoOpOverrideTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/NoOpOverrideTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections.unnecessary
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.NoOpOverride
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class NoOpOverrideTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class NoOpOverrideTest extends InspectionTest {
 
   override val inspections = Seq(new NoOpOverride)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryConversionTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryConversionTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections.unnecessary
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.unneccesary.UnnecessaryConversion
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class UnnecessaryConversionTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class UnnecessaryConversionTest extends InspectionTest {
 
   override val inspections = Seq(new UnnecessaryConversion)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryIfTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryIfTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections.unnecessary
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.unneccesary.UnnecessaryIf
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class UnnecessaryIfTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class UnnecessaryIfTest extends InspectionTest {
 
   override val inspections = Seq(new UnnecessaryIf)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryReturnUseTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnnecessaryReturnUseTest.scala
@@ -1,12 +1,10 @@
 package com.sksamuel.scapegoat.inspections.unnecessary
 
-import com.sksamuel.scapegoat.PluginRunner
+import com.sksamuel.scapegoat.InspectionTest
 import com.sksamuel.scapegoat.inspections.unneccesary.UnnecessaryReturnUse
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
 
 /** @author Stephen Samuel */
-class UnnecessaryReturnUseTest extends AnyFreeSpec with Matchers with PluginRunner {
+class UnnecessaryReturnUseTest extends InspectionTest {
 
   override val inspections = Seq(new UnnecessaryReturnUse)
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnusedMethodParameterTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/unnecessary/UnusedMethodParameterTest.scala
@@ -1,13 +1,10 @@
 package com.sksamuel.scapegoat.inspections.unnecessary
 
 import com.sksamuel.scapegoat.inspections.unneccesary.UnusedMethodParameter
-import com.sksamuel.scapegoat.{PluginRunner, Warning}
-import org.scalatest.OneInstancePerTest
-import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers
+import com.sksamuel.scapegoat.{InspectionTest, Warning}
 
 /** @author Stephen Samuel */
-class UnusedMethodParameterTest extends AnyFreeSpec with Matchers with PluginRunner with OneInstancePerTest {
+class UnusedMethodParameterTest extends InspectionTest {
 
   override val inspections = Seq(new UnusedMethodParameter)
 


### PR DESCRIPTION
As discussed in #326 not all the tests have `with OneInstancePerTest` which is believed to be required for all our tests descending from `PluginRunner`.
Adding that by introducing a common superclass.

Also it slightly reduces some boilerplate code.