### PR TITLE
Cross-build for 2.13.2.

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,8 +13,8 @@ jobs:
           - 2.11.12
           - 2.12.10
           - 2.12.11
-          - 2.13.0
           - 2.13.1
+          - 2.13.2
     steps:
       - uses: actions/checkout@v2
       - uses: olafurpg/setup-scala@v7

--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,8 @@ developers := List(
   )
 )
 
-scalaVersion := "2.13.1"
-crossScalaVersions := Seq("2.11.12", "2.12.10", "2.12.11", "2.13.0", "2.13.1")
+scalaVersion := "2.13.2"
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.12.11", "2.13.1", "2.13.2")
 autoScalaLibrary := false
 crossVersion := CrossVersion.full
 crossTarget := {

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // compiler plugins
-addCompilerPlugin(scalafixSemanticdb)
+addCompilerPlugin("org.scalameta" % "semanticdb-scalac" % "4.3.10" cross CrossVersion.full)
 
 name := "scalac-scapegoat-plugin"
 organization := "com.sksamuel.scapegoat"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Classpaths.sbtPluginReleases
 addSbtPlugin("com.geirsson"  % "sbt-ci-release" % "1.5.3")
 addSbtPlugin("com.eed3si9n"  % "sbt-assembly"   % "0.14.10")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"   % "2.3.4")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"   % "0.9.15")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"   % "0.9.15-1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage"  % "1.6.1")
 
 if (System.getProperty("add-scapegoat-plugin") == "true")


### PR DESCRIPTION
Currently blocked by the semanticdb for 2.13.2. I can see a new scalameta has just been released, so hopefully, it shouldn't be too long until it makes its way to the sbt-scalafix plugin.

Closes #350.