### PR TITLE
Fix markdown formatting.

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/CollectionPromotionToAny.scala
@@ -12,7 +12,7 @@ class CollectionPromotionToAny
       defaultLevel = Levels.Warning,
       description = "Checks for collection operations that promote the collection to Any.",
       explanation =
-        "The :+ (append) operator on collections accepts any argument you give it, which means that you can end up with e.g. Seq[Any] if your types don't match."
+        "The `:+` (append) operator on collections accepts any argument you give it, which means that you can end up with e.g. `Seq[Any]` if your types don't match."
     ) {
 
   def inspector(context: InspectionContext): Inspector =

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferMapEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferMapEmpty.scala
@@ -8,7 +8,7 @@ class PreferMapEmpty
       defaultLevel = Levels.Info,
       description = "Checks for use of Map().",
       explanation =
-        "Map[K,V]() allocates an intermediate object. Consider Map.empty which returns a singleton instance without creating a new object."
+        "`Map[K,V]()` allocates an intermediate object. Consider `Map.empty` which returns a singleton instance without creating a new object."
     ) {
 
   def inspector(context: InspectionContext): Inspector =

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferSeqEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferSeqEmpty.scala
@@ -9,7 +9,7 @@ class PreferSeqEmpty
       defaultLevel = Levels.Info,
       description = "Checks for use of Seq().",
       explanation =
-        "Seq[T]() allocates an intermediate object. Consider Seq.empty which returns a singleton instance without creating a new object."
+        "`Seq[T]()` allocates an intermediate object. Consider `Seq.empty` which returns a singleton instance without creating a new object."
     ) {
 
   def inspector(context: InspectionContext): Inspector =

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferSetEmpty.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/PreferSetEmpty.scala
@@ -9,7 +9,7 @@ class PreferSetEmpty
       defaultLevel = Levels.Info,
       description = "Checks for use of Set().",
       explanation =
-        "Set[T]() allocates an intermediate object. Consider Set.empty which returns a singleton instance without creating a new object."
+        "`Set[T]()` allocates an intermediate object. Consider `Set.empty` which returns a singleton instance without creating a new object."
     ) {
 
   def inspector(context: InspectionContext): Inspector =

--- a/src/main/scala/com/sksamuel/scapegoat/inspections/inference/PointlessTypeBounds.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/inference/PointlessTypeBounds.scala
@@ -7,8 +7,8 @@ class PointlessTypeBounds
     extends Inspection(
       text = "Pointless type bounds",
       defaultLevel = Levels.Warning,
-      description = "Finds type bounds of the form [A <: Any] or [A >: Nothing].",
-      explanation = "Type bound resolves to Nothing <: T <: Any. Did you mean to put in other bounds?"
+      description = "Finds type bounds of the form `A <: Any` or `A >: Nothing`.",
+      explanation = "Type bound resolves to `Nothing <: T <: Any`. Did you mean to put in other bounds?"
     ) {
 
   def inspector(context: InspectionContext): Inspector =


### PR DESCRIPTION
Any text block wrapped in `[]` gets parsed as a link with an empty URL, so I wrapped those instances in an inline code block along with some other code blocks I identified in the same files.

We should also probably strip the `` ` `` character from the console output (and HTML reports too) - I'm happy to do that in a separate PR if I get any 👍  here.