### PR TITLE
Log the name of the Inspection

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -35,6 +35,7 @@ class Feedback(
   ): Unit = {
     val level = inspection.defaultLevel
     val text = inspection.text
+    val name = inspection.name
     val explanation = adhocExplanation.getOrElse(inspection.explanation)
     val adjustedLevel = (
       levelOverridesByInspectionSimpleName.get("all"),
@@ -61,7 +62,7 @@ class Feedback(
 
     if (shouldPrint(warning)) {
       val snippetText = snippet.fold("")("\n  " + _ + "\n")
-      val report = s"""[scapegoat] $text
+      val report = s"""[scapegoat] [$name] $text
                       |  $explanation$snippetText""".stripMargin
 
       adjustedLevel match {

--- a/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Inspection.scala
@@ -18,6 +18,8 @@ abstract class Inspection(
   def inspector(context: InspectionContext): Inspector
 
   def isEnabled: Boolean = true
+
+  def name: String = getClass.getSimpleName
 }
 
 abstract class Inspector(val context: InspectionContext) {

--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -183,10 +183,10 @@ class ScapegoatComponent(val global: Global, inspections: Seq[Inspection])
   def activeInspections: Seq[Inspection] = {
     if (enabledInspections.isEmpty)
       (inspections ++ customInpections)
-        .filterNot(inspection => disabledInspections.contains(inspection.getClass.getSimpleName))
+        .filterNot(inspection => disabledInspections.contains(inspection.name))
     else
       (inspections ++ customInpections)
-        .filter(inspection => enabledInspections.contains(inspection.getClass.getSimpleName))
+        .filter(inspection => enabledInspections.contains(inspection.name))
   }
   lazy val feedback = new Feedback(consoleOutput, global.reporter, sourcePrefix, minimalLevel)
 

--- a/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
@@ -35,7 +35,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
         val feedback = new Feedback(true, reporter, defaultSourcePrefix)
         feedback.warn(position, inspection)
         reporter.infos should contain(
-          reporter.Info(position, "[scapegoat] My default is Error\n  This is explanation.", reporter.ERROR)
+          reporter.Info(position, "[scapegoat] [DummyInspection] My default is Error\n  This is explanation.", reporter.ERROR)
         )
       }
       "for warning" in {
@@ -50,7 +50,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
         feedback.warn(position, inspection)
         reporter.infos should contain(
           reporter
-            .Info(position, "[scapegoat] My default is Warning\n  This is explanation.", reporter.WARNING)
+            .Info(position, "[scapegoat] [DummyInspection] My default is Warning\n  This is explanation.", reporter.WARNING)
         )
       }
       "for info" in {
@@ -64,7 +64,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
         val feedback = new Feedback(true, reporter, defaultSourcePrefix)
         feedback.warn(position, inspection)
         reporter.infos should contain(
-          reporter.Info(position, "[scapegoat] My default is Info\n  This is explanation.", reporter.INFO)
+          reporter.Info(position, "[scapegoat] [DummyInspection] My default is Info\n  This is explanation.", reporter.INFO)
         )
       }
     }


### PR DESCRIPTION
This done so they can be suppressed more easily if needed.

Solves #264