### PR TITLE
Fix false positive in ComparisonToEmptyList inspection

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptyList.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptyList.scala
@@ -33,10 +33,17 @@ class ComparisonToEmptyList
               case Apply(Select(_, Equals), List(TypeApply(Select(Select(_, TermList), Empty), _))) =>
                 warn(tree)
               case Apply(Select(TypeApply(Select(Select(_, TermList), Empty), _), Equals), _) => warn(tree)
-              case Apply(Select(_, Equals), List(Apply(TypeApply(Select(_, TermApply), _), Nil))) =>
+              case Apply(
+                    Select(_, Equals),
+                    List(Apply(TypeApply(Select(Select(_, TermList), TermApply), _), Nil))
+                  ) =>
                 warn(tree)
-              case Apply(Select(Apply(TypeApply(Select(_, TermApply), _), Nil), Equals), _) => warn(tree)
-              case _                                                                        => continue(tree)
+              case Apply(
+                    Select(Apply(TypeApply(Select(Select(_, TermList), TermApply), _), Nil), Equals),
+                    _
+                  ) =>
+                warn(tree)
+              case _ => continue(tree)
             }
           }
 

--- a/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptyListTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/inspections/collections/ComparisonToEmptyListTest.scala
@@ -70,5 +70,29 @@ class ComparisonToEmptyListTest extends InspectionTest {
         compiler.scapegoat.feedback.warnings.size shouldBe 1
       }
     }
+    "should not report warning" - {
+      "for custom parameterless case class with type parameter on rhs" in {
+        val code = """object Test {
+                        case class Paramless[T]()
+
+                        val a = List(1,2,3)
+                        val b = a == Paramless()
+                    } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+      "for custom parameterless case class with type parameter on lhs" in {
+        val code = """object Test {
+                        case class Paramless[T]()
+
+                        val a = List(1,2,3)
+                        val b = Paramless() == a
+                    } """.stripMargin
+
+        compileCodeSnippet(code)
+        compiler.scapegoat.feedback.warnings.size shouldBe 0
+      }
+    }
   }
 }


### PR DESCRIPTION
In my previous commit 9ccd7405 there was no check verifying that 'apply' method is called on 'List' type, and because of that false positives were reported in cases like this:

```
object Test {
    case class Paramless[T]()

    val a = List(1,2,3)
    val b = a == Paramless()
}
```