### PR TITLE
Refactoring configuration parsing

### DIFF
--- a/src/main/scala/com/sksamuel/scapegoat/Configuration.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Configuration.scala
@@ -1,0 +1,19 @@
+package com.sksamuel.scapegoat
+
+import java.io.File
+
+case class Configuration(
+  dataDir: Option[File],
+  disabledInspections: List[String],
+  enabledInspections: List[String],
+  ignoredFiles: List[String],
+  consoleOutput: Boolean,
+  verbose: Boolean,
+  disableXML: Boolean,
+  disableHTML: Boolean,
+  disableScalastyleXML: Boolean,
+  disableMarkdown: Boolean,
+  customInspections: Seq[Inspection],
+  sourcePrefix: String,
+  minimalLevel: Level
+)

--- a/src/main/scala/com/sksamuel/scapegoat/Configuration.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Configuration.scala
@@ -73,10 +73,7 @@ object Configuration {
     }
     val dataDir = fromProperty[Option[File]](
       "dataDir",
-      defaultValue = {
-        error("-P:scapegoat:dataDir not specified")
-        None
-      }
+      defaultValue = None
     ) { value =>
       Some(new File(value))
     }

--- a/src/main/scala/com/sksamuel/scapegoat/Configuration.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Configuration.scala
@@ -15,5 +15,6 @@ case class Configuration(
   disableMarkdown: Boolean,
   customInspections: Seq[Inspection],
   sourcePrefix: String,
-  minimalLevel: Level
+  minimalLevel: Level,
+  levelOverridesByInspectionSimpleName: Map[String, Level]
 )

--- a/src/main/scala/com/sksamuel/scapegoat/Configuration.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Configuration.scala
@@ -18,3 +18,113 @@ case class Configuration(
   minimalLevel: Level,
   levelOverridesByInspectionSimpleName: Map[String, Level]
 )
+
+object Configuration {
+
+  def fromPluginOptions(options: List[String], error: String => Unit): Configuration = {
+    def fromProperty[T](propertyName: String, defaultValue: T)(fn: String => T): T = {
+      options.find(_.startsWith(propertyName + ":")) match {
+        case Some(property) =>
+          val justTheValue = property.drop(propertyName.length + 1)
+          fn(justTheValue)
+        case None =>
+          defaultValue
+      }
+    }
+
+    val disabledInspections =
+      fromProperty("disabledInspections", defaultValue = List.empty[String])(_.split(':').toList)
+    val enabledInspections =
+      fromProperty("enabledInspections", defaultValue = List.empty[String])(_.split(':').toList)
+    val consoleOutput = fromProperty("consoleOutput", defaultValue = true)(_.toBoolean)
+    val ignoredFiles =
+      fromProperty("ignoredFiles", defaultValue = List.empty[String])(_.split(':').toList)
+    val verbose = fromProperty("verbose", defaultValue = false)(_.toBoolean)
+
+    val customInspections = fromProperty("customInspectors", defaultValue = Seq.empty[Inspection]) {
+      _.split(':').toSeq
+        .map(inspection => Class.forName(inspection).getConstructor().newInstance().asInstanceOf[Inspection])
+    }
+    val enabledReports = fromProperty("reports", defaultValue = Seq("all"))(_.split(':').toSeq)
+    val disableXML = !(enabledReports.contains("xml") || enabledReports.contains("all"))
+    val disableHTML = !(enabledReports.contains("html") || enabledReports.contains("all"))
+    val disableScalastyleXML =
+      !(enabledReports.contains("scalastyle") || enabledReports.contains("all"))
+    val disableMarkdown = !(enabledReports.contains("markdown") || enabledReports.contains("all"))
+
+    val levelOverridesByInspectionSimpleName =
+      fromProperty("overrideLevels", defaultValue = Map.empty[String, Level]) {
+        _.split(":").map { nameLevel =>
+          nameLevel.split("=") match {
+            case Array(insp, level) => insp -> Levels.fromName(level)
+            case _ =>
+              throw new IllegalArgumentException(
+                s"Malformed argument to 'overrideLevels': '$nameLevel'. " +
+                "Expecting 'name=level' where 'name' is the simple name of " +
+                "an inspection and 'level' is the simple name of a " +
+                "com.sksamuel.scapegoat.Level constant, e.g. 'Warning'."
+              )
+          }
+        }.toMap
+      }
+    val sourcePrefix = fromProperty("sourcePrefix", defaultValue = "src/main/scala/")(x => x)
+    val minimalLevel = fromProperty[Level]("minimalLevel", defaultValue = Levels.Info) { value =>
+      Levels.fromName(value)
+    }
+    val dataDir = fromProperty[Option[File]](
+      "dataDir",
+      defaultValue = {
+        error("-P:scapegoat:dataDir not specified")
+        None
+      }
+    ) { value =>
+      Some(new File(value))
+    }
+
+    Configuration(
+      dataDir = dataDir,
+      disabledInspections = disabledInspections,
+      enabledInspections = enabledInspections,
+      ignoredFiles = ignoredFiles,
+      consoleOutput = consoleOutput,
+      verbose = verbose,
+      disableXML = disableXML,
+      disableHTML = disableHTML,
+      disableScalastyleXML = disableScalastyleXML,
+      disableMarkdown = disableMarkdown,
+      customInspections = customInspections,
+      sourcePrefix = sourcePrefix,
+      minimalLevel = minimalLevel,
+      levelOverridesByInspectionSimpleName = levelOverridesByInspectionSimpleName
+    )
+  }
+
+  val optionsHelp: String = {
+    Seq(
+      "-P:scapegoat:dataDir:<pathtodatadir>                 where the report should be written",
+      "-P:scapegoat:disabledInspections:<listofinspections> colon separated list of disabled inspections (defaults to none)",
+      "-P:scapegoat:enabledInspections:<listofinspections>  colon separated list of enabled inspections (defaults to all)",
+      "-P:scapegoat:customInspectors:<listofinspections>    colon separated list of custom inspections",
+      "-P:scapegoat:ignoredFiles:<patterns>                 colon separated list of regexes to match ",
+      "                                                     files to ignore.",
+      "-P:scapegoat:verbose:<boolean>                       enable/disable verbose console messages",
+      "-P:scapegoat:consoleOutput:<boolean>                 enable/disable console report output",
+      "-P:scapegoat:reports:<reports>                       colon separated list of reports to generate.",
+      "                                                     Valid options are `xml', `html', `scalastyle', 'markdown',",
+      "                                                     or `all'. Use `none' to disable reports.",
+      "-P:scapegoat:overrideLevels:<levels>                 override the built in warning levels, e.g. to",
+      "                                                     downgrade a Error to a Warning.",
+      "                                                     <levels> should be a colon separated list of name=level",
+      "                                                     settings, where 'name' is the simple name of an inspection",
+      "                                                     and 'level' is the simple name of a",
+      "                                                     com.sksamuel.scapegoat.Level constant, e.g. 'Warning'.",
+      "                                                     You can use 'all' for inspection name to operate on all inspections.",
+      "-P:scapegoat:sourcePrefix:<prefix>                   overrides source prefix if it differs from src/main/scala",
+      "                                                     for ex., in Play applications where sources are in app/ folder",
+      "-P:scapegoat:minimalWarnLevel:<level>                provides minimal level of triggered inspections,",
+      "                                                     that will be shown in a report.",
+      "                                                     'level' is the simple name of a",
+      "                                                     com.sksamuel.scapegoat.Level constant, e.g. 'Warning'."
+    ).mkString("\n")
+  }
+}

--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -8,17 +8,17 @@ import scala.tools.nsc.reporters.Reporter
  * @author Stephen Samuel
  */
 class Feedback(
-  consoleOutput: Boolean,
   reporter: Reporter,
-  sourcePrefix: String,
-  minimalLevel: Level = Levels.Info
+  configuration: Configuration
 ) {
 
   private val warningsBuffer = new ListBuffer[Warning]
 
   def warnings: Seq[Warning] = warningsBuffer.toSeq
-  def warningsWithMinimalLevel: Seq[Warning] = warnings.filter(_.hasMinimalLevelOf(minimalLevel))
-  def shouldPrint(warning: Warning): Boolean = consoleOutput && warning.hasMinimalLevelOf(minimalLevel)
+  def warningsWithMinimalLevel: Seq[Warning] =
+    warnings.filter(_.hasMinimalLevelOf(configuration.minimalLevel))
+  def shouldPrint(warning: Warning): Boolean =
+    configuration.consoleOutput && warning.hasMinimalLevelOf(configuration.minimalLevel)
 
   var levelOverridesByInspectionSimpleName: Map[String, Level] = Map.empty
 
@@ -74,6 +74,7 @@ class Feedback(
   }
 
   private def normalizeSourceFile(sourceFile: String): String = {
+    val sourcePrefix = configuration.sourcePrefix
     val indexOf = sourceFile.indexOf(sourcePrefix)
     val fullPrefix = if (sourcePrefix.endsWith("/")) sourcePrefix else s"$sourcePrefix/"
     val packageAndFile = if (indexOf == -1) sourceFile else sourceFile.drop(indexOf).drop(fullPrefix.length)

--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -20,8 +20,6 @@ class Feedback(
   def shouldPrint(warning: Warning): Boolean =
     configuration.consoleOutput && warning.hasMinimalLevelOf(configuration.minimalLevel)
 
-  var levelOverridesByInspectionSimpleName: Map[String, Level] = Map.empty
-
   def infos = warnings(Levels.Info)
   def errors = warnings(Levels.Error)
   def warns = warnings(Levels.Warning)
@@ -38,8 +36,8 @@ class Feedback(
     val name = inspection.name
     val explanation = adhocExplanation.getOrElse(inspection.explanation)
     val adjustedLevel = (
-      levelOverridesByInspectionSimpleName.get("all"),
-      levelOverridesByInspectionSimpleName.get(inspection.getClass.getSimpleName)
+      configuration.levelOverridesByInspectionSimpleName.get("all"),
+      configuration.levelOverridesByInspectionSimpleName.get(inspection.getClass.getSimpleName)
     ) match {
       case (Some(l), _)    => l
       case (None, Some(l)) => l

--- a/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Feedback.scala
@@ -36,8 +36,8 @@ class Feedback(
     val name = inspection.name
     val explanation = adhocExplanation.getOrElse(inspection.explanation)
     val adjustedLevel = (
-      configuration.levelOverridesByInspectionSimpleName.get("all"),
-      configuration.levelOverridesByInspectionSimpleName.get(inspection.getClass.getSimpleName)
+      configuration.overrideLevels.get("all"),
+      configuration.overrideLevels.get(inspection.getClass.getSimpleName)
     ) match {
       case (Some(l), _)    => l
       case (None, Some(l)) => l

--- a/src/main/scala/com/sksamuel/scapegoat/Inspections.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/Inspections.scala
@@ -21,7 +21,7 @@ import com.sksamuel.scapegoat.inspections.unsafe._
 /**
  * @author Stephen Samuel
  */
-object ScapegoatConfig extends App {
+object Inspections extends App {
 
   def inspections: Seq[Inspection] =
     Seq(

--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -18,6 +18,9 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
 
   override def init(options: List[String], error: String => Unit): Boolean = {
     component.configuration = Configuration.fromPluginOptions(options, error)
+    if (component.configuration.dataDir.isEmpty) {
+      error("-P:scapegoat:dataDir not specified")
+    }
     component.configuration.dataDir.isDefined
   }
 

--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -17,7 +17,7 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
   override val components: List[PluginComponent] = List(component)
 
   override def init(options: List[String], error: String => Unit): Boolean = {
-    component.configuration = Configuration.fromPluginOptions(options, error)
+    component.configuration = Configuration.fromPluginOptions(options)
     if (component.configuration.dataDir.isEmpty) {
       error("-P:scapegoat:dataDir not specified")
     }
@@ -51,10 +51,10 @@ class ScapegoatComponent(val global: Global, inspections: Seq[Inspection])
 
   def activeInspections: Seq[Inspection] = {
     if (configuration.enabledInspections.isEmpty)
-      (inspections ++ configuration.customInspections)
+      (inspections ++ configuration.customInspectors)
         .filterNot(inspection => configuration.disabledInspections.contains(inspection.name))
     else
-      (inspections ++ configuration.customInspections)
+      (inspections ++ configuration.customInspectors)
         .filter(inspection => configuration.enabledInspections.contains(inspection.name))
   }
   lazy val feedback = new Feedback(global.reporter, configuration)
@@ -91,10 +91,11 @@ class ScapegoatComponent(val global: Global, inspections: Seq[Inspection])
             )
           }
 
-          writeReport(configuration.disableHTML, "HTML", IOUtils.writeHTMLReport)
-          writeReport(configuration.disableXML, "XML", IOUtils.writeXMLReport)
-          writeReport(configuration.disableScalastyleXML, "Scalastyle XML", IOUtils.writeScalastyleReport)
-          writeReport(configuration.disableMarkdown, "Markdown", IOUtils.writeMarkdownReport)
+          val reports = configuration.reports
+          writeReport(reports.disableHTML, "HTML", IOUtils.writeHTMLReport)
+          writeReport(reports.disableXML, "XML", IOUtils.writeXMLReport)
+          writeReport(reports.disableScalastyleXML, "Scalastyle XML", IOUtils.writeScalastyleReport)
+          writeReport(reports.disableMarkdown, "Markdown", IOUtils.writeMarkdownReport)
         }
       }
     }

--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -47,8 +47,7 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
       !(enabledReports.contains("scalastyle") || enabledReports.contains("all"))
     val disableMarkdown = !(enabledReports.contains("markdown") || enabledReports.contains("all"))
 
-    // TODO That should go into configuration too
-    component.feedback.levelOverridesByInspectionSimpleName =
+    val levelOverridesByInspectionSimpleName =
       fromProperty("overrideLevels", defaultValue = Map.empty[String, Level]) {
         _.split(":").map { nameLevel =>
           nameLevel.split("=") match {
@@ -90,7 +89,8 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
       disableMarkdown = disableMarkdown,
       customInspections = customInspections,
       sourcePrefix = sourcePrefix,
-      minimalLevel = minimalLevel
+      minimalLevel = minimalLevel,
+      levelOverridesByInspectionSimpleName = levelOverridesByInspectionSimpleName
     )
 
     component.configuration.dataDir.isDefined

--- a/src/main/scala/com/sksamuel/scapegoat/plugin.scala
+++ b/src/main/scala/com/sksamuel/scapegoat/plugin.scala
@@ -17,114 +17,11 @@ class ScapegoatPlugin(val global: Global) extends Plugin {
   override val components: List[PluginComponent] = List(component)
 
   override def init(options: List[String], error: String => Unit): Boolean = {
-    def fromProperty[T](propertyName: String, defaultValue: T)(fn: String => T): T = {
-      options.find(_.startsWith(propertyName + ":")) match {
-        case Some(property) =>
-          val justTheValue = property.drop(propertyName.length + 1)
-          fn(justTheValue)
-        case None =>
-          defaultValue
-      }
-    }
-
-    val disabledInspections =
-      fromProperty("disabledInspections", defaultValue = List.empty[String])(_.split(':').toList)
-    val enabledInspections =
-      fromProperty("enabledInspections", defaultValue = List.empty[String])(_.split(':').toList)
-    val consoleOutput = fromProperty("consoleOutput", defaultValue = true)(_.toBoolean)
-    val ignoredFiles =
-      fromProperty("ignoredFiles", defaultValue = List.empty[String])(_.split(':').toList)
-    val verbose = fromProperty("verbose", defaultValue = false)(_.toBoolean)
-
-    val customInspections = fromProperty("customInspectors", defaultValue = Seq.empty[Inspection]) {
-      _.split(':').toSeq
-        .map(inspection => Class.forName(inspection).getConstructor().newInstance().asInstanceOf[Inspection])
-    }
-    val enabledReports = fromProperty("reports", defaultValue = Seq("all"))(_.split(':').toSeq)
-    val disableXML = !(enabledReports.contains("xml") || enabledReports.contains("all"))
-    val disableHTML = !(enabledReports.contains("html") || enabledReports.contains("all"))
-    val disableScalastyleXML =
-      !(enabledReports.contains("scalastyle") || enabledReports.contains("all"))
-    val disableMarkdown = !(enabledReports.contains("markdown") || enabledReports.contains("all"))
-
-    val levelOverridesByInspectionSimpleName =
-      fromProperty("overrideLevels", defaultValue = Map.empty[String, Level]) {
-        _.split(":").map { nameLevel =>
-          nameLevel.split("=") match {
-            case Array(insp, level) => insp -> Levels.fromName(level)
-            case _ =>
-              throw new IllegalArgumentException(
-                s"Malformed argument to 'overrideLevels': '$nameLevel'. " +
-                "Expecting 'name=level' where 'name' is the simple name of " +
-                "an inspection and 'level' is the simple name of a " +
-                "com.sksamuel.scapegoat.Level constant, e.g. 'Warning'."
-              )
-          }
-        }.toMap
-      }
-    val sourcePrefix = fromProperty("sourcePrefix", defaultValue = "src/main/scala/")(x => x)
-    val minimalLevel = fromProperty[Level]("minimalLevel", defaultValue = Levels.Info) { value =>
-      Levels.fromName(value)
-    }
-    val dataDir = fromProperty[Option[File]](
-      "dataDir",
-      defaultValue = {
-        error("-P:scapegoat:dataDir not specified")
-        None
-      }
-    ) { value =>
-      Some(new File(value))
-    }
-
-    component.configuration = Configuration(
-      dataDir = dataDir,
-      disabledInspections = disabledInspections,
-      enabledInspections = enabledInspections,
-      ignoredFiles = ignoredFiles,
-      consoleOutput = consoleOutput,
-      verbose = verbose,
-      disableXML = disableXML,
-      disableHTML = disableHTML,
-      disableScalastyleXML = disableScalastyleXML,
-      disableMarkdown = disableMarkdown,
-      customInspections = customInspections,
-      sourcePrefix = sourcePrefix,
-      minimalLevel = minimalLevel,
-      levelOverridesByInspectionSimpleName = levelOverridesByInspectionSimpleName
-    )
-
+    component.configuration = Configuration.fromPluginOptions(options, error)
     component.configuration.dataDir.isDefined
   }
 
-  override val optionsHelp: Option[String] = Some(
-    Seq(
-      "-P:scapegoat:dataDir:<pathtodatadir>                 where the report should be written",
-      "-P:scapegoat:disabledInspections:<listofinspections> colon separated list of disabled inspections (defaults to none)",
-      "-P:scapegoat:enabledInspections:<listofinspections>  colon separated list of enabled inspections (defaults to all)",
-      "-P:scapegoat:customInspectors:<listofinspections>    colon separated list of custom inspections",
-      "-P:scapegoat:ignoredFiles:<patterns>                 colon separated list of regexes to match ",
-      "                                                     files to ignore.",
-      "-P:scapegoat:verbose:<boolean>                       enable/disable verbose console messages",
-      "-P:scapegoat:consoleOutput:<boolean>                 enable/disable console report output",
-      "-P:scapegoat:reports:<reports>                       colon separated list of reports to generate.",
-      "                                                     Valid options are `xml', `html', `scalastyle', 'markdown',",
-      "                                                     or `all'. Use `none' to disable reports.",
-      "-P:scapegoat:overrideLevels:<levels>                 override the built in warning levels, e.g. to",
-      "                                                     downgrade a Error to a Warning.",
-      "                                                     <levels> should be a colon separated list of name=level",
-      "                                                     settings, where 'name' is the simple name of an inspection",
-      "                                                     and 'level' is the simple name of a",
-      "                                                     com.sksamuel.scapegoat.Level constant, e.g. 'Warning'.",
-      "                                                     You can use 'all' for inspection name to operate on all inspections.",
-      "-P:scapegoat:sourcePrefix:<prefix>                   overrides source prefix if it differs from src/main/scala",
-      "                                                     for ex., in Play applications where sources are in app/ folder",
-      "-P:scapegoat:minimalWarnLevel:<level>                provides minimal level of triggered inspections,",
-      "                                                     that will be shown in a report.",
-      "                                                     'level' is the simple name of a",
-      "                                                     com.sksamuel.scapegoat.Level constant, e.g. 'Warning'."
-    ).mkString("\n")
-  )
-
+  override val optionsHelp: Option[String] = Some(Configuration.optionsHelp)
 }
 
 class ScapegoatComponent(val global: Global, inspections: Seq[Inspection])

--- a/src/test/scala/com/sksamuel/scapegoat/AllInspectionsTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/AllInspectionsTest.scala
@@ -7,7 +7,7 @@ class AllInspectionsTest extends AnyFreeSpec with Matchers {
 
   val code = "\\s[A-Za-z0-9.]+\\(\\)\\s".r
 
-  ScapegoatConfig.inspections.foreach { insp =>
+  Inspections.inspections.foreach { insp =>
     insp.getClass.getSimpleName - {
       "should have a properly-formatted description" in {
         insp.description.trim shouldNot be("")

--- a/src/test/scala/com/sksamuel/scapegoat/ConfigurationTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/ConfigurationTest.scala
@@ -1,0 +1,21 @@
+package com.sksamuel.scapegoat
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConfigurationTest extends AnyFreeSpec with Matchers {
+
+  "Configuration" - {
+    "should list all possible options in its help" - {
+      // NOTE: also enforcing the internal field name is the same as the public one
+
+      val existingOptions = classOf[Configuration].getDeclaredFields.map(_.getName)
+
+      existingOptions.foreach { option =>
+        s"$option should be listed in help" in {
+          Configuration.optionsHelp.contains(s"-P:scapegoat:$option:") shouldBe true
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/FeedbackTest.scala
@@ -32,7 +32,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is explanation."
         )
         val reporter = new StoreReporter
-        val feedback = new Feedback(true, reporter, defaultSourcePrefix)
+        val feedback = new Feedback(reporter, testConfiguration(true, defaultSourcePrefix))
         feedback.warn(position, inspection)
         reporter.infos should contain(
           reporter.Info(
@@ -50,7 +50,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is explanation."
         )
         val reporter = new StoreReporter
-        val feedback = new Feedback(true, reporter, defaultSourcePrefix)
+        val feedback = new Feedback(reporter, testConfiguration(true, defaultSourcePrefix))
         feedback.warn(position, inspection)
         reporter.infos should contain(
           reporter
@@ -69,7 +69,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
           "This is explanation."
         )
         val reporter = new StoreReporter
-        val feedback = new Feedback(true, reporter, defaultSourcePrefix)
+        val feedback = new Feedback(reporter, testConfiguration(true, defaultSourcePrefix))
         feedback.warn(position, inspection)
         reporter.infos should contain(
           reporter.Info(
@@ -84,7 +84,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
       "for `src/main/scala`" in {
         val normalizeSourceFile = PrivateMethod[String](Symbol("normalizeSourceFile"))
         val reporter = new StoreReporter
-        val feedback = new Feedback(true, reporter, defaultSourcePrefix)
+        val feedback = new Feedback(reporter, testConfiguration(true, defaultSourcePrefix))
         val source = "src/main/scala/com/sksamuel/scapegoat/Test.scala"
         val result = feedback invokePrivate normalizeSourceFile(source)
         result should ===("com.sksamuel.scapegoat.Test.scala")
@@ -93,7 +93,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
       "for `app`" in {
         val normalizeSourceFile = PrivateMethod[String](Symbol("normalizeSourceFile"))
         val reporter = new StoreReporter
-        val feedback = new Feedback(true, reporter, "app/")
+        val feedback = new Feedback(reporter, testConfiguration(true, "app/"))
         val source = "app/com/sksamuel/scapegoat/Test.scala"
         val result = feedback invokePrivate normalizeSourceFile(source)
         result should ===("com.sksamuel.scapegoat.Test.scala")
@@ -102,7 +102,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
       "should add trailing / to the sourcePrefix automatically" in {
         val normalizeSourceFile = PrivateMethod[String](Symbol("normalizeSourceFile"))
         val reporter = new StoreReporter
-        val feedback = new Feedback(true, reporter, "app/custom")
+        val feedback = new Feedback(reporter, testConfiguration(true, "app/custom"))
         val source = "app/custom/com/sksamuel/scapegoat/Test.scala"
         val result = feedback invokePrivate normalizeSourceFile(source)
         result should ===("com.sksamuel.scapegoat.Test.scala")
@@ -130,7 +130,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
         )
         val inspections = Seq(inspectionError, inspectionWarning, inspectionInfo)
         val reporter = new StoreReporter
-        val feedback = new Feedback(true, reporter, defaultSourcePrefix, Levels.Info)
+        val feedback = new Feedback(reporter, testConfiguration(true, defaultSourcePrefix, Levels.Info))
         inspections.foreach(inspection => feedback.warn(position, inspection))
         feedback.warningsWithMinimalLevel.length should be(3)
       }
@@ -156,7 +156,7 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
         )
         val inspections = Seq(inspectionError, inspectionWarning, inspectionInfo)
         val reporter = new StoreReporter
-        val feedback = new Feedback(false, reporter, defaultSourcePrefix, Levels.Warning)
+        val feedback = new Feedback(reporter, testConfiguration(false, defaultSourcePrefix, Levels.Warning))
         inspections.foreach(inspection => feedback.warn(position, inspection))
         feedback.warningsWithMinimalLevel.length should be(2)
         feedback.warningsWithMinimalLevel
@@ -184,11 +184,22 @@ class FeedbackTest extends AnyFreeSpec with Matchers with OneInstancePerTest wit
         )
         val inspections = Seq(inspectionError, inspectionWarning, inspectionInfo)
         val reporter = new StoreReporter
-        val feedback = new Feedback(false, reporter, defaultSourcePrefix, Levels.Error)
+        val feedback = new Feedback(reporter, testConfiguration(false, defaultSourcePrefix, Levels.Error))
         inspections.foreach(inspection => feedback.warn(position, inspection))
         feedback.warningsWithMinimalLevel.length should be(1)
         feedback.warningsWithMinimalLevel.map(_.level) should contain only (Seq(Levels.Error): _*)
       }
     }
   }
+
+  private def testConfiguration(
+    consoleOutput: Boolean,
+    sourcePrefix: String,
+    minimalLevel: Level = Levels.Info
+  ) =
+    TestConfiguration.configuration.copy(
+      consoleOutput = consoleOutput,
+      sourcePrefix = sourcePrefix,
+      minimalLevel = minimalLevel
+    )
 }

--- a/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/PluginRunner.scala
@@ -87,11 +87,8 @@ class ScapegoatCompiler(
 ) extends scala.tools.nsc.Global(settings, reporter) {
 
   val scapegoat = new ScapegoatComponent(this, inspections)
-  scapegoat.disableHTML = true
-  scapegoat.disableXML = true
-  scapegoat.disableScalastyleXML = true
-  scapegoat.verbose = false
   scapegoat.summary = false
+  scapegoat.configuration = TestConfiguration.configuration
 
   override def computeInternalPhases(): Unit = {
     super.computeInternalPhases()

--- a/src/test/scala/com/sksamuel/scapegoat/ReadmeTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/ReadmeTest.scala
@@ -49,5 +49,16 @@ class ReadmeTest extends AnyFreeSpec with Matchers {
         n.toInt shouldBe inspectionNamesAndLevels.size
       }
     }
+
+    "should mention all existing configuration options" - {
+      val existingOptions = classOf[Configuration].getDeclaredFields.map(_.getName)
+      val readmeText = readme.mkString("\n")
+
+      existingOptions.foreach { option =>
+        s"$option should be listed in help" in {
+          readmeText.contains(s"-P:scapegoat:$option:") shouldBe true
+        }
+      }
+    }
   }
 }

--- a/src/test/scala/com/sksamuel/scapegoat/ReadmeTest.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/ReadmeTest.scala
@@ -24,7 +24,7 @@ class ReadmeTest extends AnyFreeSpec with Matchers {
       }
 
   val inspectionNamesAndLevels =
-    ScapegoatConfig.inspections.map(i => i.getClass.getSimpleName -> i.defaultLevel.toString).toSet
+    Inspections.inspections.map(i => i.getClass.getSimpleName -> i.defaultLevel.toString).toSet
 
   "README" - {
     "should be up to date" in {

--- a/src/test/scala/com/sksamuel/scapegoat/TestConfiguration.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/TestConfiguration.scala
@@ -15,6 +15,7 @@ object TestConfiguration {
     disableMarkdown = true,
     customInspections = Seq(),
     sourcePrefix = "src/main/scala",
-    minimalLevel = Levels.Info
+    minimalLevel = Levels.Info,
+    levelOverridesByInspectionSimpleName = Map.empty[String, Level]
   )
 }

--- a/src/test/scala/com/sksamuel/scapegoat/TestConfiguration.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/TestConfiguration.scala
@@ -9,13 +9,15 @@ object TestConfiguration {
     ignoredFiles = List(),
     consoleOutput = false,
     verbose = false,
-    disableXML = true,
-    disableHTML = true,
-    disableScalastyleXML = true,
-    disableMarkdown = true,
-    customInspections = Seq(),
+    reports = Reports(
+      disableXML = true,
+      disableHTML = true,
+      disableScalastyleXML = true,
+      disableMarkdown = true
+    ),
+    customInspectors = Seq(),
     sourcePrefix = "src/main/scala",
     minimalLevel = Levels.Info,
-    levelOverridesByInspectionSimpleName = Map.empty[String, Level]
+    overrideLevels = Map.empty[String, Level]
   )
 }

--- a/src/test/scala/com/sksamuel/scapegoat/TestConfiguration.scala
+++ b/src/test/scala/com/sksamuel/scapegoat/TestConfiguration.scala
@@ -1,0 +1,20 @@
+package com.sksamuel.scapegoat
+
+object TestConfiguration {
+
+  def configuration = Configuration(
+    dataDir = None,
+    disabledInspections = List(),
+    enabledInspections = List(),
+    ignoredFiles = List(),
+    consoleOutput = false,
+    verbose = false,
+    disableXML = true,
+    disableHTML = true,
+    disableScalastyleXML = true,
+    disableMarkdown = true,
+    customInspections = Seq(),
+    sourcePrefix = "src/main/scala",
+    minimalLevel = Levels.Info
+  )
+}


### PR DESCRIPTION
#439 suggests we should offer another way of configuring Scapegoat.
Before that happens, let's clean-up the process of parsing/accepting the configuration input.

Pure refactoring, no changes to the logic (... intended).