### PR TITLE
Run the release Github Action only in the main repo, not in forks

### DIFF
--- a/.github/workflows/master-release.yml
+++ b/.github/workflows/master-release.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.repository == ‘sksamuel/scapegoat’
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow


### PR DESCRIPTION
**Why**
I have a fork of this repo which I keep on updating. Every time I do that I get an email from Github:
>  [mccartney/scapegoat] Release workflow run 
> Release: All jobs have failed

The run fails with this error message:
> gpg: no valid OpenPGP data found.

No surprise my fork shouldn't be able to publish a snapshot release of the library.

**What**
Attempt at having the action run only in the main repo.