### PR TITLE
Use Codecov Token

### DIFF
--- a/.github/workflows/master-codecov.yml
+++ b/.github/workflows/master-codecov.yml
@@ -27,3 +27,4 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/master-codecov.yml
+++ b/.github/workflows/master-codecov.yml
@@ -25,3 +25,5 @@ jobs:
       - name: Generate coverage report
         run: sbt clean coverage test coverageReport
       - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
       - name: Run Scalafix check
         run: sbt fixCheck
       - name: Run Scapegoat

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -55,6 +55,8 @@ jobs:
       - name: Generate coverage report
         run: sbt clean coverage test coverageReport
       - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Run Scalafix check
         run: sbt fixCheck
       - name: Run Scapegoat


### PR DESCRIPTION
According to https://github.com/codecov/codecov-action since v4 it is required to pass the token. Since we updated to v4 our coverage report is comparing to the latest master before the update.

I don't have enough collaborator permissions to check if we have that secret defined in the project settings. It seems not to be there. @sksamuel, maybe you could add it please?

Fixes #859.